### PR TITLE
feat : add @NoArgsConstructor, @AllArgsConstructor in  single field Dto

### DIFF
--- a/src/main/java/com/springboot/api/dto/counselee/DeleteCounseleeBatchReq.java
+++ b/src/main/java/com/springboot/api/dto/counselee/DeleteCounseleeBatchReq.java
@@ -1,11 +1,15 @@
 package com.springboot.api.dto.counselee;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class DeleteCounseleeBatchReq {
     @NotBlank
     private String counseleeId;


### PR DESCRIPTION
@Builder 사용 시

DTO class 의 field가 1개인 경우
private로  싱글-파라미터 생성자가 자동으로 생성됨.

이때 파라미터 없는 기본 생성자가 자동으로 만들어지지 않으므로
Jackson에서 dto 역직렬화 과정에서 제대로 동작하지 않음.

이를 해결 하기 위해

@NoArgsConstructor
@AllArgsConstructor

붙임.