### PR TITLE
Feature: convert webm to mp4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,23 @@ RUN ./gradlew clean build -x test
 
 
 FROM amazoncorretto:21.0.4
+
+RUN amazon-linux-extras enable epel && \
+    yum install -y ffmpeg && \
+    yum clean all
+
+ENV PATH="/usr/bin/ffmpeg:${PATH}"
+
+
+
 ENV APP_HOME=/apps
 ARG ARTIFACT_NAME=app.jar
 ARG JAR_FILE_PATH=build/libs/api-0.0.1-SNAPSHOT.jar
 
 WORKDIR $APP_HOME
+
+RUN mkdir -p /data/stt/audio/origin /data/stt/audio/convert && \
+    chmod -R 766 /data/stt/audio
 
 #COPY --from=build /apps/build/libs/demo-0.0.1-SNAPSHOT.jar app.jar
 COPY --from=build $APP_HOME/$JAR_FILE_PATH $ARTIFACT_NAME

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
     //Spring AI
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:1.0.0-SNAPSHOT'
+    implementation 'net.bramp.ffmpeg:ffmpeg:0.6.2'
 }
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/springboot/api/common/properties/FfmpegProperties.java
+++ b/src/main/java/com/springboot/api/common/properties/FfmpegProperties.java
@@ -1,0 +1,14 @@
+package com.springboot.api.common.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix="stt.file.path")
+@Getter
+@Setter
+public class FfmpegProperties {
+    private String path;
+}

--- a/src/main/java/com/springboot/api/common/properties/NaverClovaProperties.java
+++ b/src/main/java/com/springboot/api/common/properties/NaverClovaProperties.java
@@ -1,0 +1,15 @@
+package com.springboot.api.common.properties;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix="ffmpeg")
+@Getter
+@Setter
+public class NaverClovaProperties {
+    private String apiKey;
+}

--- a/src/main/java/com/springboot/api/common/properties/SttFileProperties.java
+++ b/src/main/java/com/springboot/api/common/properties/SttFileProperties.java
@@ -1,0 +1,16 @@
+package com.springboot.api.common.properties;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix="naver.clova")
+@Getter
+@Setter
+public class SttFileProperties {
+    private String origin;
+    private String covert;
+}

--- a/src/main/java/com/springboot/api/common/util/FileUtil.java
+++ b/src/main/java/com/springboot/api/common/util/FileUtil.java
@@ -1,12 +1,13 @@
 package com.springboot.api.common.util;
 
 import com.springboot.api.common.dto.ByteArrayMultipartFile;
+import com.springboot.api.common.properties.FfmpegProperties;
 import de.huxhorn.sulky.ulid.ULID;
 import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
 import net.bramp.ffmpeg.FFmpeg;
 import net.bramp.ffmpeg.builder.FFmpegBuilder;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,11 +18,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 @Component
+@RequiredArgsConstructor
 public class FileUtil {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(FileUtil.class);
-    @Value("${ffmpeg.path}")
-    private String ffmpegPath;
+
+    private final FfmpegProperties ffmpegProperties;
 
     public File convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
         File tempFile = File.createTempFile("upload_", multipartFile.getOriginalFilename());
@@ -63,7 +65,7 @@ public class FileUtil {
         String savedMultipartFileName = saveMultipartFile(multipartFile, originFilePath);
         String convertedMultipartFileName = savedMultipartFileName.replace(".webm",".mp4");
 
-        FFmpeg ffmpeg = new FFmpeg(ffmpegPath);
+        FFmpeg ffmpeg = new FFmpeg(ffmpegProperties.getPath());
 
         FFmpegBuilder builder = new FFmpegBuilder()
                 .setInput(originFilePath+savedMultipartFileName)

--- a/src/main/java/com/springboot/api/common/util/FileUtil.java
+++ b/src/main/java/com/springboot/api/common/util/FileUtil.java
@@ -1,17 +1,93 @@
 package com.springboot.api.common.util;
 
+import com.springboot.api.common.dto.ByteArrayMultipartFile;
+import de.huxhorn.sulky.ulid.ULID;
+import jakarta.validation.constraints.NotNull;
+import net.bramp.ffmpeg.FFmpeg;
+import net.bramp.ffmpeg.builder.FFmpegBuilder;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 @Component
 public class FileUtil {
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(FileUtil.class);
+    @Value("${ffmpeg.path}")
+    private String ffmpegPath;
 
     public File convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
         File tempFile = File.createTempFile("upload_", multipartFile.getOriginalFilename());
         multipartFile.transferTo(tempFile);
         return tempFile;
     }
+
+
+
+    private String saveMultipartFile(@NotNull MultipartFile multipartFile,@NotNull String saveFilePath) throws IOException {
+
+        if(multipartFile.isEmpty()){
+            throw new IllegalArgumentException();
+        }
+
+        Path dirPath = Path.of(saveFilePath);
+
+        if (!Files.exists(dirPath)) {
+            Files.createDirectories(dirPath);
+        }
+
+        String hash =  new ULID().nextULID();
+        String hashedFilename = hash + multipartFile.getOriginalFilename();
+
+        log.debug(hashedFilename);
+
+        Path filePath = dirPath.resolve(hashedFilename);
+
+        Files.copy(multipartFile.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+
+        return hashedFilename;
+
+    }
+
+
+    public MultipartFile convertWebmToMp4(MultipartFile multipartFile,String originFilePath,String convertFilePath) throws IOException {
+
+
+        String savedMultipartFileName = saveMultipartFile(multipartFile, originFilePath);
+        String convertedMultipartFileName = savedMultipartFileName.replace(".webm",".mp4");
+
+        FFmpeg ffmpeg = new FFmpeg(ffmpegPath);
+
+        FFmpegBuilder builder = new FFmpegBuilder()
+                .setInput(originFilePath+savedMultipartFileName)
+                .overrideOutputFiles(true)
+                .addOutput(convertFilePath+convertedMultipartFileName)  // 출력 파일 설정
+                .setFormat("mp4")  // 출력 포맷 설정
+                .setAudioCodec("aac")  // 오디오 코덱 설정 (AAC)
+                .setAudioBitRate(192000)  // 오디오 비트레이트 설정 (192kbps)
+                .done();
+
+        ffmpeg.run(builder);
+
+        File mp4File = new File(convertFilePath+convertedMultipartFileName);
+        byte[] fileBytes = Files.readAllBytes(mp4File.toPath());
+        MultipartFile convertedMultipartFile = new ByteArrayMultipartFile("media"
+                ,convertedMultipartFileName
+                , "audio/mp4"
+                , fileBytes);
+
+        Files.delete(Path.of(originFilePath+savedMultipartFileName));
+        Files.delete(Path.of(convertFilePath+convertedMultipartFileName));
+
+
+        return convertedMultipartFile;
+    }
+
 }

--- a/src/main/java/com/springboot/api/service/AICounselSummaryService.java
+++ b/src/main/java/com/springboot/api/service/AICounselSummaryService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springboot.api.common.dto.ByteArrayMultipartFile;
 import com.springboot.api.common.exception.NoContentException;
+import com.springboot.api.common.properties.NaverClovaProperties;
+import com.springboot.api.common.properties.SttFileProperties;
 import com.springboot.api.common.util.DateTimeUtil;
 import com.springboot.api.common.util.FileUtil;
 import com.springboot.api.domain.AICounselSummary;
@@ -27,7 +29,6 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,15 +53,9 @@ public class AICounselSummaryService {
     private final ObjectMapper objectMapper;
     private final NaverClovaExternalService naverClovaExternalService;
     private final DateTimeUtil dateTimeUtil;
-    @Value("${naver.clova.api-key}")
-    private String clovaApiKey;
+    private final NaverClovaProperties naverClovaProperties;
     private final ChatModel chatModel;
-
-    @Value("${stt.file.path.origin}")
-    private String sttOriginPath;
-
-    @Value("${stt.file.path.convert}")
-    private String sttConvertPath;
+    private final SttFileProperties sttFileProperties;
 
     private final FileUtil fileUtil;
 
@@ -84,7 +79,7 @@ public class AICounselSummaryService {
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Accept","application/json");
-        headers.put("X-CLOVASPEECH-API-KEY",clovaApiKey);
+        headers.put("X-CLOVASPEECH-API-KEY",naverClovaProperties.getApiKey());
 
         SpeechToTextReq speechToTextReq = SpeechToTextReq
                 .builder()
@@ -117,7 +112,7 @@ public class AICounselSummaryService {
 
                 if (Objects.requireNonNull(file.getContentType()).contains("webm"))
                 {
-                    multipartFile = fileUtil.convertWebmToMp4(file,sttOriginPath,sttConvertPath);
+                    multipartFile = fileUtil.convertWebmToMp4(file,sttFileProperties.getOrigin(),sttFileProperties.getCovert());
                 }
                 else
                 {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,16 @@ naver:
 api:
   userdetails:
     implementation: counselorUserDetailsService
+
+stt:
+  file:
+    path:
+      origin: /data/stt/audio/origin/
+      convert: /data/stt/audio/convert/
+
+ffmpeg:
+  path: /usr/local/bin/ffmpeg
+
 logging:
   level:
     org.springframework.security: DEBUG

--- a/src/test/java/com/springboot/api/common/FileUtilTest.java
+++ b/src/test/java/com/springboot/api/common/FileUtilTest.java
@@ -1,0 +1,91 @@
+package com.springboot.api.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.springboot.api.common.util.FileUtil;
+import com.springboot.api.dto.naverClova.SpeechToTextReq;
+import com.springboot.api.dto.naverClova.SpeechToTextRes;
+import com.springboot.api.infra.external.NaverClovaExternalService;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.ResourceUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.support.RestTemplateAdapter;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@SpringBootTest
+@Disabled
+public class FileUtilTest {
+
+    @Autowired
+    FileUtil fileUtil;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test5.webm"})
+    void testConvertWebmToM4a(String filename) throws IOException {
+
+        File mp4File = ResourceUtils.getFile("classpath:" + "stt/audio/"+filename);
+        FileInputStream inputStream = new FileInputStream(mp4File);
+        String originPath = "/Users/choisunpil/Desktop/development/2024/spring-boot-boilerplate/src/test/resources/stt/audio/test/origin/";
+        String convertPath = "/Users/choisunpil/Desktop/development/2024/spring-boot-boilerplate/src/test/resources/stt/audio/test/convert/";
+
+        MultipartFile multipartFile = new MockMultipartFile(
+                "media",
+                mp4File.getName(),
+                "audio/webm",
+                inputStream);
+
+        MultipartFile convertedMultipartFile = fileUtil.convertWebmToMp4(multipartFile, originPath, convertPath);
+
+
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setUriTemplateHandler(new DefaultUriBuilderFactory("https://clovaspeech-gw.ncloud.com/external/v1/10309/338f74c076c81a57b47313f867ab35519c289e3f8dede43066bea9f266708cb1"));
+        RestTemplateAdapter adapter = RestTemplateAdapter.create(restTemplate);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+
+        NaverClovaExternalService service = factory.createClient(NaverClovaExternalService.class);
+
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept","application/json");
+        headers.put("X-CLOVASPEECH-API-KEY","796d7a638753441eb241a266f1f10d49");
+
+
+        SpeechToTextReq speechToTextReq = SpeechToTextReq
+                .builder()
+                .language("ko-KR")
+                .completion("sync")
+                .wordAlignment(true)
+                .fullText(true)
+                .build();
+
+
+        SpeechToTextRes speechToTextRes = service.convertSpeechToText(headers, convertedMultipartFile, speechToTextReq).getBody();
+
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        File file = new File("src/test/resources/stt/output/"+mp4File.getName()+".json");
+        objectMapper.writeValue(file, speechToTextRes);
+
+
+
+
+
+    }
+
+}

--- a/src/test/java/com/springboot/api/common/STTTest.java
+++ b/src/test/java/com/springboot/api/common/STTTest.java
@@ -50,7 +50,7 @@ public class STTTest {
     private static final Logger log = LoggerFactory.getLogger(STTTest.class);
 
     @ParameterizedTest
-    @ValueSource(strings = {"test5.m4a"})
+    @ValueSource(strings = {"test5.webm"})
     public void testTransformSTT(String filename) throws IOException, SecurityException {
 
         RestTemplate restTemplate = new RestTemplate();


### PR DESCRIPTION
현재 브라우저에서 녹음 시, webm 파일로 생성됨.
clova speech api는 현재 webm 미지원.

따라서 
webm 파일로 stt 하려면 인코딩 변환 해야함.


원래는
m4a로 진행하려 했으나, 현재 ffmpeg 는 m4a 미지원
따라서 m4a -> mp4로 변환하여 전송함.


stt 프로세스는 아래와 같음

--비동기--
2.webm 이면, mp4로 변환
   1. origin 경로에 임시 저장 후 ffmpeg 통해 convert 경로로 떨굼
   2. Multipart 객체 생성
   3. origin, convert 경로 파일 삭제
3. naver clova api 호출
