### PR TITLE
Refactor counselee

### DIFF
--- a/src/main/java/com/springboot/api/common/config/initializer/TestDataInitializer.java
+++ b/src/main/java/com/springboot/api/common/config/initializer/TestDataInitializer.java
@@ -283,7 +283,7 @@ public class TestDataInitializer implements CommandLineRunner {
                              }
                 """);
 
-        JsonNode independentLifeInformation = counselee.isDisability() ? objectMapper.readTree("""
+        JsonNode independentLifeInformation = counselee.getIsDisability() ? objectMapper.readTree("""
                 {
                                  "version": "1.0",
                                  "walking": {

--- a/src/main/java/com/springboot/api/common/util/DateTimeUtil.java
+++ b/src/main/java/com/springboot/api/common/util/DateTimeUtil.java
@@ -20,7 +20,7 @@ public class DateTimeUtil {
         }
     }
 
-    public int calculateKoreanAge(LocalDate birthDate, LocalDate currentDate) throws RuntimeException {
+    public static int calculateKoreanAge(LocalDate birthDate, LocalDate currentDate) throws RuntimeException {
 
         if (birthDate == null || currentDate == null) {
             throw new IllegalArgumentException("Dates cannot be null");

--- a/src/main/java/com/springboot/api/domain/Counselee.java
+++ b/src/main/java/com/springboot/api/domain/Counselee.java
@@ -2,7 +2,10 @@ package com.springboot.api.domain;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
+import com.springboot.api.dto.counselee.AddCounseleeReq;
+import com.springboot.api.dto.counselee.UpdateCounseleeReq;
 import com.springboot.enums.GenderType;
 import com.springboot.enums.HealthInsuranceType;
 
@@ -21,23 +24,18 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Table(name = "counselees", uniqueConstraints = {
-        @UniqueConstraint(columnNames = { "name", "date_of_birth", "phone_number" })
+        @UniqueConstraint(columnNames = {"name", "date_of_birth", "phone_number"})
 })
-@Data
+@Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true, exclude = { "counselSessions", "medicationRecords", })
-@ToString(callSuper = true, exclude = { "counselSessions", "medicationRecords" })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = true, exclude = {"counselSessions", "medicationRecords",})
+@ToString(callSuper = true, exclude = {"counselSessions", "medicationRecords"})
 public class Counselee extends BaseEntity {
 
     @Column(nullable = false)
@@ -81,12 +79,12 @@ public class Counselee extends BaseEntity {
 
     private String address;
 
-    private boolean isDisability;
+    private Boolean isDisability;
 
     @Column(name = "care_manager_name")
     private String careManagerName;
 
-    @OneToMany(mappedBy = "counselee", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "counselee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CounselSession> counselSessions;
 
     @OneToMany(mappedBy = "counselee", cascade = CascadeType.ALL)
@@ -99,5 +97,37 @@ public class Counselee extends BaseEntity {
     @Override
     protected void onCreate() {
         super.onCreate();
+    }
+
+    public Counselee(AddCounseleeReq addCounseleeReq) {
+        this.name = addCounseleeReq.getName();
+        this.dateOfBirth = addCounseleeReq.getDateOfBirth();
+        this.phoneNumber = addCounseleeReq.getPhoneNumber();
+        this.counselCount = 0;
+        this.registrationDate = LocalDate.now();
+        this.affiliatedWelfareInstitution = addCounseleeReq.getAffiliatedWelfareInstitution();
+        this.note = addCounseleeReq.getNote();
+        this.genderType = addCounseleeReq.getGenderType();
+        this.healthInsuranceType = HealthInsuranceType.NON_COVERED;
+        this.address = addCounseleeReq.getAddress();
+        this.isDisability = addCounseleeReq.isDisability();
+        this.careManagerName = addCounseleeReq.getCareManagerName();
+    }
+
+    public void update(UpdateCounseleeReq updateCounseleeReq) {
+        this.name = Objects.requireNonNullElse(updateCounseleeReq.getName(), this.name);
+        this.phoneNumber = Objects.requireNonNullElse(updateCounseleeReq.getPhoneNumber(), this.phoneNumber);
+        this.dateOfBirth = Objects.requireNonNullElse(updateCounseleeReq.getDateOfBirth(), this.dateOfBirth);
+        this.genderType = Objects.requireNonNullElse(updateCounseleeReq.getGenderType(), this.genderType);
+        this.address = Objects.requireNonNullElse(updateCounseleeReq.getAddress(), this.address);
+        this.isDisability = Objects.requireNonNullElse(updateCounseleeReq.getIsDisability(), this.isDisability);
+        this.note = Objects.requireNonNullElse(updateCounseleeReq.getNote(), this.note);
+        this.careManagerName = Objects.requireNonNullElse(updateCounseleeReq.getCareManagerName(), this.careManagerName);
+        this.affiliatedWelfareInstitution = Objects.requireNonNullElse(updateCounseleeReq.getAffiliatedWelfareInstitution(), this.affiliatedWelfareInstitution);
+    }
+
+    public void counselSessionComplete(LocalDate lastCounselDate) {
+        this.counselCount++;
+        this.lastCounselDate = lastCounselDate;
     }
 }

--- a/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeBaseInformationByCounseleeIdRes.java
+++ b/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeBaseInformationByCounseleeIdRes.java
@@ -17,7 +17,7 @@ public record SelectCounseleeBaseInformationByCounseleeIdRes(
                 HealthInsuranceType healthInsuranceType, int counselCount, LocalDate lastCounselDate,
                 List<String> diseases, CardRecordStatus cardRecordStatus, boolean isDisability) {
 
-    public static SelectCounseleeBaseInformationByCounseleeIdRes of(Counselee counselee, List<String> diseases, CardRecordStatus cardRecordStatus) {
+    public static SelectCounseleeBaseInformationByCounseleeIdRes from(Counselee counselee, List<String> diseases, CardRecordStatus cardRecordStatus) {
         return SelectCounseleeBaseInformationByCounseleeIdRes.builder()
                 .counseleeId(counselee.getId())
                 .name(counselee.getName())

--- a/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeBaseInformationByCounseleeIdRes.java
+++ b/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeBaseInformationByCounseleeIdRes.java
@@ -1,12 +1,9 @@
 package com.springboot.api.dto.counselee;
 
-import java.sql.Struct;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import com.springboot.api.common.util.DateTimeUtil;
-import com.springboot.api.domain.CounselCard;
 import com.springboot.api.domain.Counselee;
 import com.springboot.enums.CardRecordStatus;
 import com.springboot.enums.GenderType;
@@ -20,21 +17,20 @@ public record SelectCounseleeBaseInformationByCounseleeIdRes(
                 HealthInsuranceType healthInsuranceType, int counselCount, LocalDate lastCounselDate,
                 List<String> diseases, CardRecordStatus cardRecordStatus, boolean isDisability) {
 
-//    public static SelectCounseleeBaseInformationByCounseleeIdRes of(Counselee counselee, List<String> diseases){
-//        return SelectCounseleeBaseInformationByCounseleeIdRes.builder()
-//                .counseleeId(counselee.getId())
-//                .name(counselee.getName())
-//                .age(DateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
-//                .dateOfBirth(counselee.getDateOfBirth().toString())
-//                .gender(counselee.getGenderType())
-//                .address(counselee.getAddress())
-//                .healthInsuranceType(counselee.getHealthInsuranceType())
-//                .counselCount(counselee.getCounselCount())
-//                .lastCounselDate(counselee.getLastCounselDate())
-//                .diseases(diseases)
-//                .cardRecordStatus(Optional.ofNullable(currentCounselCard).map(CounselCard::getCardRecordStatus)
-//                        .orElse(CardRecordStatus.UNRECORDED))
-//                .isDisability(counselee.getIsDisability())
-//                .build();
-//    }
+    public static SelectCounseleeBaseInformationByCounseleeIdRes of(Counselee counselee, List<String> diseases, CardRecordStatus cardRecordStatus) {
+        return SelectCounseleeBaseInformationByCounseleeIdRes.builder()
+                .counseleeId(counselee.getId())
+                .name(counselee.getName())
+                .age(DateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
+                .dateOfBirth(counselee.getDateOfBirth().toString())
+                .gender(counselee.getGenderType())
+                .address(counselee.getAddress())
+                .healthInsuranceType(counselee.getHealthInsuranceType())
+                .counselCount(counselee.getCounselCount())
+                .lastCounselDate(counselee.getLastCounselDate())
+                .diseases(diseases)
+                .cardRecordStatus(cardRecordStatus)
+                .isDisability(counselee.getIsDisability())
+                .build();
+    }
 }

--- a/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeBaseInformationByCounseleeIdRes.java
+++ b/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeBaseInformationByCounseleeIdRes.java
@@ -1,8 +1,13 @@
 package com.springboot.api.dto.counselee;
 
+import java.sql.Struct;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+import com.springboot.api.common.util.DateTimeUtil;
+import com.springboot.api.domain.CounselCard;
+import com.springboot.api.domain.Counselee;
 import com.springboot.enums.CardRecordStatus;
 import com.springboot.enums.GenderType;
 import com.springboot.enums.HealthInsuranceType;
@@ -14,4 +19,22 @@ public record SelectCounseleeBaseInformationByCounseleeIdRes(
                 String counseleeId, String name, int age, String dateOfBirth, GenderType gender, String address,
                 HealthInsuranceType healthInsuranceType, int counselCount, LocalDate lastCounselDate,
                 List<String> diseases, CardRecordStatus cardRecordStatus, boolean isDisability) {
+
+//    public static SelectCounseleeBaseInformationByCounseleeIdRes of(Counselee counselee, List<String> diseases){
+//        return SelectCounseleeBaseInformationByCounseleeIdRes.builder()
+//                .counseleeId(counselee.getId())
+//                .name(counselee.getName())
+//                .age(DateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
+//                .dateOfBirth(counselee.getDateOfBirth().toString())
+//                .gender(counselee.getGenderType())
+//                .address(counselee.getAddress())
+//                .healthInsuranceType(counselee.getHealthInsuranceType())
+//                .counselCount(counselee.getCounselCount())
+//                .lastCounselDate(counselee.getLastCounselDate())
+//                .diseases(diseases)
+//                .cardRecordStatus(Optional.ofNullable(currentCounselCard).map(CounselCard::getCardRecordStatus)
+//                        .orElse(CardRecordStatus.UNRECORDED))
+//                .isDisability(counselee.getIsDisability())
+//                .build();
+//    }
 }

--- a/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeRes.java
+++ b/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeRes.java
@@ -31,7 +31,7 @@ public class SelectCounseleeRes {
     private String note;
     private boolean isDisability;
 
-    public static SelectCounseleeRes of(Counselee counselee) {
+    public static SelectCounseleeRes from (Counselee counselee) {
         return SelectCounseleeRes.builder()
                 .id(counselee.getId())
                 .name(counselee.getName())

--- a/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeRes.java
+++ b/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeRes.java
@@ -2,13 +2,19 @@ package com.springboot.api.dto.counselee;
 
 import java.time.LocalDate;
 
+import com.springboot.api.common.util.DateTimeUtil;
+import com.springboot.api.domain.Counselee;
 import com.springboot.enums.GenderType;
 import com.springboot.enums.HealthInsuranceType;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+
+@Getter
 @Builder
-@Data
+@AllArgsConstructor
 public class SelectCounseleeRes {
     private String id;
     private String name;
@@ -25,5 +31,25 @@ public class SelectCounseleeRes {
     private String careManagerName;
     private String note;
     private boolean isDisability;
+
+    public static SelectCounseleeRes of(Counselee counselee, DateTimeUtil dateTimeUtil) {
+        return SelectCounseleeRes.builder()
+                .id(counselee.getId())
+                .name(counselee.getName())
+                .age(dateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
+                .dateOfBirth(counselee.getDateOfBirth())
+                .phoneNumber(counselee.getPhoneNumber())
+                .gender(counselee.getGenderType())
+                .address(counselee.getAddress())
+                .affiliatedWelfareInstitution(counselee.getAffiliatedWelfareInstitution())
+                .healthInsuranceType(counselee.getHealthInsuranceType())
+                .counselCount(counselee.getCounselCount())
+                .lastCounselDate(counselee.getLastCounselDate())
+                .registrationDate(counselee.getRegistrationDate())
+                .careManagerName(counselee.getCareManagerName())
+                .note(counselee.getNote())
+                .isDisability(counselee.getIsDisability())
+                .build();
+    }
 }
 

--- a/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeRes.java
+++ b/src/main/java/com/springboot/api/dto/counselee/SelectCounseleeRes.java
@@ -9,7 +9,6 @@ import com.springboot.enums.HealthInsuranceType;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 
 @Getter
@@ -32,11 +31,11 @@ public class SelectCounseleeRes {
     private String note;
     private boolean isDisability;
 
-    public static SelectCounseleeRes of(Counselee counselee, DateTimeUtil dateTimeUtil) {
+    public static SelectCounseleeRes of(Counselee counselee) {
         return SelectCounseleeRes.builder()
                 .id(counselee.getId())
                 .name(counselee.getName())
-                .age(dateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
+                .age(DateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
                 .dateOfBirth(counselee.getDateOfBirth())
                 .phoneNumber(counselee.getPhoneNumber())
                 .gender(counselee.getGenderType())

--- a/src/main/java/com/springboot/api/dto/counselee/UpdateCounseleeReq.java
+++ b/src/main/java/com/springboot/api/dto/counselee/UpdateCounseleeReq.java
@@ -28,7 +28,8 @@ public class UpdateCounseleeReq {
     @Past(message = "생년월일은 과거 날짜여야 합니다")
     private LocalDate dateOfBirth;
 
-    @ValidEnum(enumClass = GenderType.class)
+    //TODO : 현재 validation이 null 일 경우 실패가 되는데, nullable로 처리하게 변경해야 함
+    // @ValidEnum(enumClass = GenderType.class)
     private GenderType genderType;
 
     @Size(max = 200, message = "주소는 200자를 초과할 수 없습니다")

--- a/src/main/java/com/springboot/api/dto/counselee/UpdateCounseleeReq.java
+++ b/src/main/java/com/springboot/api/dto/counselee/UpdateCounseleeReq.java
@@ -6,11 +6,9 @@ import com.springboot.api.common.annotation.ValidEnum;
 import com.springboot.enums.GenderType;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import jakarta.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
 
@@ -21,15 +19,12 @@ public class UpdateCounseleeReq {
     @Size(min = 26, max = 26, message = "내담자 ID는 26자여야 합니다")
     private String counseleeId;
 
-    @NotBlank(message = "이름은 필수 입력값입니다")
     @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하여야 합니다")
     private String name;
 
-    @NotBlank(message = "전화번호는 필수 입력값입니다")
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다")
     private String phoneNumber;
 
-    @NotNull(message = "생년월일은 필수 입력값입니다")
     @Past(message = "생년월일은 과거 날짜여야 합니다")
     private LocalDate dateOfBirth;
 
@@ -39,17 +34,14 @@ public class UpdateCounseleeReq {
     @Size(max = 200, message = "주소는 200자를 초과할 수 없습니다")
     private String address;
 
-    private boolean isDisability;
+    private Boolean isDisability;
 
     @Size(max = 1000, message = "비고는 1000자를 초과할 수 없습니다")
-    @Nullable
     private String note;
 
     @Size(max = 50, message = "담당자 이름은 50자를 초과할 수 없습니다")
-    @Nullable
     private String careManagerName;
 
     @Size(max = 100, message = "복지기관명은 100자를 초과할 수 없습니다")
-    @Nullable
     private String affiliatedWelfareInstitution;
 }

--- a/src/main/java/com/springboot/api/dto/counselsession/UpdateStatusInCounselSessionReq.java
+++ b/src/main/java/com/springboot/api/dto/counselsession/UpdateStatusInCounselSessionReq.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 
 @Builder
 public record UpdateStatusInCounselSessionReq(
-                @NotBlank(message = "상담 세션 ID는 필수 입력값입니다") @Size(min = 26, max = 26, message = "상담 세션 ID는 26자여야 합니다") String counselSessionId,
-                @NotNull(message = "상담 상태는 필수 입력값입니다") ScheduleStatus status) {
+                @NotBlank(message = "상담 세션 ID는 필수 입력값입니다")
+                @Size(min = 26, max = 26, message = "상담 세션 ID는 26자여야 합니다")
+                String counselSessionId,
+                @NotNull(message = "상담 상태는 필수 입력값입니다")
+                ScheduleStatus status) {
 }

--- a/src/main/java/com/springboot/api/repository/CounselCardRepository.java
+++ b/src/main/java/com/springboot/api/repository/CounselCardRepository.java
@@ -2,8 +2,18 @@ package com.springboot.api.repository;
 
 import com.springboot.api.domain.CounselCard;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CounselCardRepository extends JpaRepository<CounselCard, String> {
 
-
+    @Query("""
+            SELECT cd FROM CounselCard cd
+            WHERE cd.counselSession.counselee.id = :counseleeId
+            AND cd.cardRecordStatus = 'RECORDED'
+            ORDER BY cd.counselSession.scheduledStartDateTime DESC
+            LIMIT 1
+            """)
+    Optional<CounselCard> findLastRecordedCounselCard(String counseleeId);
 }

--- a/src/main/java/com/springboot/api/repository/CounseleeRepositoryCustom.java
+++ b/src/main/java/com/springboot/api/repository/CounseleeRepositoryCustom.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface CounseleeRepositoryCustom {
     Page<Counselee> findWithFilters(
@@ -17,4 +18,6 @@ public interface CounseleeRepositoryCustom {
     List<LocalDate> findDistinctBirthDates();
 
     List<String> findDistinctAffiliatedWelfareInstitutions();
+
+    Optional<Counselee> findByCounselSessionId(String counselSessionId);
 }

--- a/src/main/java/com/springboot/api/repository/CounseleeRepositoryImpl.java
+++ b/src/main/java/com/springboot/api/repository/CounseleeRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class CounseleeRepositoryImpl extends QuerydslRepositorySupport implements CounseleeRepositoryCustom {
@@ -88,5 +89,15 @@ public class CounseleeRepositoryImpl extends QuerydslRepositorySupport implement
                 .where(counselee.affiliatedWelfareInstitution.isNotNull())
                 .orderBy(counselee.affiliatedWelfareInstitution.asc())
                 .fetch();
+    }
+
+    @Override
+    public Optional<Counselee> findByCounselSessionId(String counselSessionId) {
+        QCounselee counselee = QCounselee.counselee;
+        return Optional.ofNullable(queryFactory
+                .selectFrom(counselee)
+                .innerJoin(counselee.counselSessions)
+                .where(counselee.counselSessions.any().id.eq(counselSessionId))
+                .fetchOne());
     }
 }

--- a/src/main/java/com/springboot/api/service/CounselSessionService.java
+++ b/src/main/java/com/springboot/api/service/CounselSessionService.java
@@ -234,13 +234,7 @@ public class CounselSessionService {
                 if (ScheduleStatus.COMPLETED.equals(updateStatusInCounselSessionReq.status())) {
                         Counselee counselee = counselSession.getCounselee();
                         if (counselee != null) {
-                                // 완료된 상담 세션 수 계산
-                                long completedCount = counselee.getCounselSessions().stream()
-                                                .filter(session -> ScheduleStatus.COMPLETED.equals(session.getStatus()))
-                                                .count();
-
-                                counselee.setCounselCount((int) completedCount);
-                                counselee.setLastCounselDate(counselSession.getScheduledStartDateTime().toLocalDate());
+                                counselee.counselSessionComplete(counselSession.getScheduledStartDateTime().toLocalDate());
                         }
                 }
 

--- a/src/main/java/com/springboot/api/service/CounseleeService.java
+++ b/src/main/java/com/springboot/api/service/CounseleeService.java
@@ -35,8 +35,8 @@ import java.util.stream.Collectors;
 public class CounseleeService {
 
     private final CounseleeRepository counseleeRepository;
-    public final CounselSessionRepository counselSessionRepository;
-    public final DateTimeUtil dateTimeUtil;
+    private final CounselSessionRepository counselSessionRepository;
+    private final DateTimeUtil dateTimeUtil;
 
     public SelectCounseleeBaseInformationByCounseleeIdRes selectCounseleeBaseInformation(String counselSessionId) {
 
@@ -64,7 +64,6 @@ public class CounseleeService {
             }
         }
 
-        // Step 6: 결과 반환
         return new SelectCounseleeBaseInformationByCounseleeIdRes(counselee.getId(), counselee.getName(),
                 dateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()),
                 counselee.getDateOfBirth().toString(), counselee.getGenderType(), counselee.getAddress(),
@@ -143,17 +142,10 @@ public class CounseleeService {
             List<LocalDate> birthDates, List<String> affiliatedWelfareInstitutions) {
 
         PageRequest pageRequest = PageRequest.of(page, size);
-        Page<Counselee> counseleePage;
-        if (name == null && (birthDates == null || birthDates.isEmpty())
-                && (affiliatedWelfareInstitutions == null || affiliatedWelfareInstitutions.isEmpty())) {
-            counseleePage = counseleeRepository.findAll(pageRequest);
-        } else {
-            counseleePage = counseleeRepository.findWithFilters(name, birthDates,
-                    affiliatedWelfareInstitutions, pageRequest);
-        }
+        Page<Counselee> counseleePage = counseleeRepository.findWithFilters(name, birthDates,
+                affiliatedWelfareInstitutions, pageRequest);
 
         List<SelectCounseleeRes> content = counseleePage.getContent().stream()
-                .sorted(Comparator.comparing(Counselee::getRegistrationDate).reversed())
                 .map(counselee -> SelectCounseleeRes.builder()
                         .id(counselee.getId())
                         .name(counselee.getName())

--- a/src/main/java/com/springboot/api/service/CounseleeService.java
+++ b/src/main/java/com/springboot/api/service/CounseleeService.java
@@ -95,23 +95,7 @@ public class CounseleeService {
     public SelectCounseleeRes selectCounselee(String counseleeId) {
         Counselee counselee = counseleeRepository.findById(counseleeId)
                 .orElseThrow(IllegalArgumentException::new);
-        return SelectCounseleeRes.builder()
-                .id(counselee.getId())
-                .name(counselee.getName())
-                .age(dateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
-                .dateOfBirth(counselee.getDateOfBirth())
-                .phoneNumber(counselee.getPhoneNumber())
-                .gender(counselee.getGenderType())
-                .address(counselee.getAddress())
-                .affiliatedWelfareInstitution(counselee.getAffiliatedWelfareInstitution())
-                .healthInsuranceType(counselee.getHealthInsuranceType())
-                .counselCount(counselee.getCounselCount())
-                .lastCounselDate(counselee.getLastCounselDate())
-                .registrationDate(counselee.getRegistrationDate())
-                .careManagerName(counselee.getCareManagerName())
-                .note(counselee.getNote())
-                .isDisability(counselee.isDisability())
-                .build();
+        return SelectCounseleeRes.of(counselee, dateTimeUtil);
     }
 
     public SelectCounseleePageRes selectCounselees(int page, int size, String name,
@@ -121,23 +105,7 @@ public class CounseleeService {
                 affiliatedWelfareInstitutions, PageRequest.of(page, size));
 
         List<SelectCounseleeRes> content = counseleePage.getContent().stream()
-                .map(counselee -> SelectCounseleeRes.builder()
-                        .id(counselee.getId())
-                        .name(counselee.getName())
-                        .age(dateTimeUtil.calculateKoreanAge(counselee.getDateOfBirth(), LocalDate.now()))
-                        .dateOfBirth(counselee.getDateOfBirth())
-                        .phoneNumber(counselee.getPhoneNumber())
-                        .gender(counselee.getGenderType())
-                        .address(counselee.getAddress())
-                        .affiliatedWelfareInstitution(counselee.getAffiliatedWelfareInstitution())
-                        .healthInsuranceType(counselee.getHealthInsuranceType())
-                        .counselCount(counselee.getCounselCount())
-                        .lastCounselDate(counselee.getLastCounselDate())
-                        .registrationDate(counselee.getRegistrationDate())
-                        .careManagerName(counselee.getCareManagerName())
-                        .note(counselee.getNote())
-                        .isDisability(counselee.isDisability())
-                        .build())
+                .map(counselee -> SelectCounseleeRes.of(counselee, dateTimeUtil))
                 .collect(Collectors.toList());
 
         return new SelectCounseleePageRes(

--- a/src/main/java/com/springboot/api/service/CounseleeService.java
+++ b/src/main/java/com/springboot/api/service/CounseleeService.java
@@ -2,7 +2,6 @@ package com.springboot.api.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.springboot.api.common.exception.NoContentException;
-import com.springboot.api.common.util.DateTimeUtil;
 import com.springboot.api.domain.CounselCard;
 import com.springboot.api.domain.Counselee;
 import com.springboot.api.dto.counselee.*;
@@ -53,7 +52,7 @@ public class CounseleeService {
             }
         }
 
-        return SelectCounseleeBaseInformationByCounseleeIdRes.of(counselee, diseases,
+        return SelectCounseleeBaseInformationByCounseleeIdRes.from(counselee, diseases,
                 Optional.ofNullable(counselCard).map(CounselCard::getCardRecordStatus)
                         .orElse(CardRecordStatus.UNRECORDED));
     }
@@ -77,7 +76,7 @@ public class CounseleeService {
     public SelectCounseleeRes selectCounselee(String counseleeId) {
         Counselee counselee = counseleeRepository.findById(counseleeId)
                 .orElseThrow(IllegalArgumentException::new);
-        return SelectCounseleeRes.of(counselee);
+        return SelectCounseleeRes.from(counselee);
     }
 
     public SelectCounseleePageRes selectCounselees(int page, int size, String name,
@@ -87,7 +86,7 @@ public class CounseleeService {
                 affiliatedWelfareInstitutions, PageRequest.of(page, size));
 
         List<SelectCounseleeRes> content = counseleePage.getContent().stream()
-                .map(counselee -> SelectCounseleeRes.of(counselee))
+                .map(SelectCounseleeRes::from)
                 .collect(Collectors.toList());
 
         return new SelectCounseleePageRes(


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- Counselee 리팩토링

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
- DTO 생성 from 함수를 사용하게 변경, DTO 생성에 사용되는 calculateKoreanAge 함수 static으로 변경
- Counselee 생성 및 업데이트를 Counselee 객체 안으로 넣음
- Counselee을 업데이트 할때, 모든 값을 넣지 않고, 변경할 값만 넣을 수 있게 변경
- queryDSL 도입으로 필요 없어진 로직 제거
- selectCounseleeBaseInformation 함수 로직 변경
   기존 로직은 다음과 같습니다.

  CounseleeSession에서 CounselCard가 없거나, RECORDING인 상태라면, 이전 상담 세션에 있는 CounselCard를 조회.
  ```java
  // 이전 상담 세션을 가져오는 메서드
          List<CounselSession> previousCounselSessions = counselSessionRepository
                  .findByCounseleeIdAndScheduledStartDateTimeLessThan(counseleeId, scheduledStartDateTime);
  ```
  여기에서 문제점이 이전 상담 세션에 있는 CounselCard를 가져올때, 정렬을 하지 않아서, 이전에 작성된 CounselCard 중 아무거나 조회하게 되어있습니다.

   기존 로직이 가장 최근의 CounselCard를 조회해오는 로직이라고 이해하여, 다음과 같이 변경했습니다.

   1. CounseleeSession에서 Counselee를 찾지 않고, CounseleeRepository에서 Counselee를 조회하게 변경
   2. Counselee의 CounselCard 중에서 가장 최근에 작성된 CounselCard를 조회해서 사용


## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
- 전반적으로 service에 있는 코드들을 DTO 및 Entity쪽으로 이동했습니다.
- Entity는 무분별하게 수정되지 못하도록, setter함수를 모두 제거하고, 값 변경이 필요할 경우에는 의미 있는 메서드를 사용하도록 변경했습니다.
- Entity에 있는 NoArgsConstructor는 JPA에서만 사용되기 때문에 access = AccessLevel.PROTECTED를 추가하였습니다.

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
* 변경 이후 테스트는 몇번 진행하였으나, 테스트 코드가 미흡하여, 테스트 코드 추가가 필요합니다.
* 변경된 selectCounseleeBaseInformation 함수 로직이 맞는지 검증이 필요합니다.
* 쿼리 최적화가 필요합니다.