### PR TITLE
refactor: refactor the counsel session domain

### DIFF
--- a/src/main/java/com/springboot/api/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/springboot/api/common/exception/handler/GlobalExceptionHandler.java
@@ -35,103 +35,103 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 @Order(2)
 public class GlobalExceptionHandler extends CommonHandler {
 
-        // 400 - 잘못된 요청 예외 처리
-        @ExceptionHandler(MethodArgumentNotValidException.class)
-        @ResponseStatus(HttpStatus.BAD_REQUEST)
-        public ResponseEntity<CommonRes<ValidationErrorRes>> handleValidationException(
-                        MethodArgumentNotValidException ex) {
-                List<ValidationError> errors = ex.getBindingResult()
-                                .getFieldErrors()
+    // 400 - 잘못된 요청 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<CommonRes<ValidationErrorRes>> handleValidationException(
+            MethodArgumentNotValidException ex) {
+        List<ValidationError> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> ValidationError.builder()
+                        .field(error.getField())
+                        .message("Invalid request")
+                        .build())
+                .collect(Collectors.toList());
+
+        ValidationErrorRes errorResponse = ValidationErrorRes.builder()
+                .errors(errors)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonRes<>(errorResponse));
+    }
+
+    // 잘못된 요청 파라미터 처리
+    @ExceptionHandler({MissingServletRequestParameterException.class, MethodArgumentTypeMismatchException.class,
+            IllegalArgumentException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorRes handleBadRequest(Exception ex) {
+        return buildErrorResponse(ex.getMessage());
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorRes handleNotFound(Exception ex) {
+        return buildErrorResponse(HttpMessages.NOT_FOUND);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ErrorRes handleAccessDenied(Exception ex) {
+        return buildErrorResponse(HttpMessages.FORBIDDEN);
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorRes handleAuthenticationCredentialsNotFoundException(Exception ex) {
+        return buildErrorResponse(HttpMessages.UNAUTHORIZED);
+    }
+
+    // JPA 엔터티가 이미 존재할 때 처리
+    @ExceptionHandler(EntityExistsException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorRes handleEntityExistsException(EntityExistsException ex) {
+        return buildErrorResponse(HttpMessages.CONFLICT_DUPLICATE);
+    }
+
+    @ExceptionHandler(JsonProcessingException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorRes handleJsonProcessingException(JsonProcessingException ex) {
+        return buildErrorResponse(ExceptionMessages.FAIL_JSON_CONVERT);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorRes handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        return buildErrorResponse(HttpMessages.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<CommonRes<ValidationErrorRes>> handleMethodValidationException(
+            HandlerMethodValidationException ex) {
+        List<ValidationError> errors = ex.getAllValidationResults()
+                .stream()
+                .map(error -> ValidationError.builder()
+                        .field(error.getMethodParameter().getParameterName())
+                        .message(error.getResolvableErrors()
                                 .stream()
-                                .map(error -> ValidationError.builder()
-                                                .field(error.getField())
-                                                .message("Invalid request")
-                                                .build())
-                                .collect(Collectors.toList());
+                                .findFirst()
+                                .map(err -> err.getDefaultMessage())
+                                .orElse("Invalid request"))
+                        .build())
+                .collect(Collectors.toList());
 
-                ValidationErrorRes errorResponse = ValidationErrorRes.builder()
-                                .errors(errors)
-                                .build();
+        ValidationErrorRes errorResponse = ValidationErrorRes.builder()
+                .errors(errors)
+                .build();
 
-                return ResponseEntity
-                                .status(HttpStatus.BAD_REQUEST)
-                                .body(new CommonRes<>(errorResponse));
-        }
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonRes<>(errorResponse));
+    }
 
-        // 잘못된 요청 파라미터 처리
-        @ExceptionHandler({ MissingServletRequestParameterException.class, MethodArgumentTypeMismatchException.class,
-                        IllegalArgumentException.class })
-        @ResponseStatus(HttpStatus.BAD_REQUEST)
-        public ErrorRes handleBadRequest(Exception ex) {
-                return buildErrorResponse(HttpMessages.BAD_REQUEST_PARAMETER);
-        }
-
-        @ExceptionHandler(NoResourceFoundException.class)
-        @ResponseStatus(HttpStatus.NOT_FOUND)
-        public ErrorRes handleNotFound(Exception ex) {
-                return buildErrorResponse(HttpMessages.NOT_FOUND);
-        }
-
-        @ExceptionHandler(AccessDeniedException.class)
-        @ResponseStatus(HttpStatus.FORBIDDEN)
-        public ErrorRes handleAccessDenied(Exception ex) {
-                return buildErrorResponse(HttpMessages.FORBIDDEN);
-        }
-
-        @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
-        @ResponseStatus(HttpStatus.UNAUTHORIZED)
-        public ErrorRes handleAuthenticationCredentialsNotFoundException(Exception ex) {
-                return buildErrorResponse(HttpMessages.UNAUTHORIZED);
-        }
-
-        // JPA 엔터티가 이미 존재할 때 처리
-        @ExceptionHandler(EntityExistsException.class)
-        @ResponseStatus(HttpStatus.CONFLICT)
-        public ErrorRes handleEntityExistsException(EntityExistsException ex) {
-                return buildErrorResponse(HttpMessages.CONFLICT_DUPLICATE);
-        }
-
-        @ExceptionHandler(JsonProcessingException.class)
-        @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-        public ErrorRes handleJsonProcessingException(JsonProcessingException ex) {
-                return buildErrorResponse(ExceptionMessages.FAIL_JSON_CONVERT);
-        }
-
-        @ExceptionHandler(HttpMessageNotReadableException.class)
-        @ResponseStatus(HttpStatus.BAD_REQUEST)
-        public ErrorRes handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
-                return buildErrorResponse(HttpMessages.BAD_REQUEST);
-        }
-
-        @ExceptionHandler(HandlerMethodValidationException.class)
-        @ResponseStatus(HttpStatus.BAD_REQUEST)
-        public ResponseEntity<CommonRes<ValidationErrorRes>> handleMethodValidationException(
-                        HandlerMethodValidationException ex) {
-                List<ValidationError> errors = ex.getAllValidationResults()
-                                .stream()
-                                .map(error -> ValidationError.builder()
-                                                .field(error.getMethodParameter().getParameterName())
-                                                .message(error.getResolvableErrors()
-                                                                .stream()
-                                                                .findFirst()
-                                                                .map(err -> err.getDefaultMessage())
-                                                                .orElse("Invalid request"))
-                                                .build())
-                                .collect(Collectors.toList());
-
-                ValidationErrorRes errorResponse = ValidationErrorRes.builder()
-                                .errors(errors)
-                                .build();
-
-                return ResponseEntity
-                                .status(HttpStatus.BAD_REQUEST)
-                                .body(new CommonRes<>(errorResponse));
-        }
-
-        // 500 - 서버 에러 처리
-        @ExceptionHandler(Exception.class)
-        @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-        public ErrorRes handleGeneralException(Exception ex) {
-                return buildErrorResponse(HttpMessages.INTERNAL_SERVER_ERROR);
-        }
+    // 500 - 서버 에러 처리
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorRes handleGeneralException(Exception ex) {
+        return buildErrorResponse(HttpMessages.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/src/main/java/com/springboot/api/controller/CounselSessionController.java
+++ b/src/main/java/com/springboot/api/controller/CounselSessionController.java
@@ -1,181 +1,162 @@
 package com.springboot.api.controller;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-
 import com.springboot.api.common.annotation.ApiController;
 import com.springboot.api.common.annotation.RoleSecured;
 import com.springboot.api.common.dto.CommonCursorRes;
 import com.springboot.api.common.dto.CommonRes;
-import com.springboot.api.dto.counselsession.AddCounselSessionReq;
-import com.springboot.api.dto.counselsession.AddCounselSessionRes;
-import com.springboot.api.dto.counselsession.CounselSessionStatRes;
-import com.springboot.api.dto.counselsession.DeleteCounselSessionReq;
-import com.springboot.api.dto.counselsession.DeleteCounselSessionRes;
-import com.springboot.api.dto.counselsession.SelectCounselSessionListByBaseDateAndCursorAndSizeReq;
-import com.springboot.api.dto.counselsession.SelectCounselSessionListByBaseDateAndCursorAndSizeRes;
-import com.springboot.api.dto.counselsession.SelectCounselSessionListItem;
-import com.springboot.api.dto.counselsession.SelectCounselSessionRes;
-import com.springboot.api.dto.counselsession.SelectPreviousCounselSessionListRes;
-import com.springboot.api.dto.counselsession.UpdateCounselSessionReq;
-import com.springboot.api.dto.counselsession.UpdateCounselSessionRes;
-import com.springboot.api.dto.counselsession.UpdateCounselorInCounselSessionReq;
-import com.springboot.api.dto.counselsession.UpdateCounselorInCounselSessionRes;
-import com.springboot.api.dto.counselsession.UpdateStatusInCounselSessionReq;
-import com.springboot.api.dto.counselsession.UpdateStatusInCounselSessionRes;
+import com.springboot.api.dto.counselsession.*;
 import com.springboot.api.service.CounselSessionService;
 import com.springboot.enums.RoleType;
-
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @ApiController(name = "CounselSessionController", description = "상담 세션 관련 API를 제공하는 Controller", path = "/v1/counsel/session")
 @RequiredArgsConstructor
 public class CounselSessionController {
 
-        private final CounselSessionService counselSessionService;
+    private final CounselSessionService counselSessionService;
 
-        @Operation(summary = "상담세션(일정) 추가", tags = { "관리자 화면" })
-        @PostMapping
-        @RoleSecured(RoleType.ROLE_ADMIN)
-        public ResponseEntity<CommonRes<AddCounselSessionRes>> addCounselSession(
-                        @RequestBody @Valid AddCounselSessionReq addCounselSessionReq) {
+    @Operation(summary = "상담세션(일정) 추가", tags = {"관리자 화면"})
+    @PostMapping
+    @RoleSecured(RoleType.ROLE_ADMIN)
+    public ResponseEntity<CommonRes<AddCounselSessionRes>> addCounselSession(
+            @RequestBody @Valid AddCounselSessionReq addCounselSessionReq) {
 
-                AddCounselSessionRes addCounselSessionRes = counselSessionService
-                                .addCounselSession(addCounselSessionReq);
+        AddCounselSessionRes addCounselSessionRes = counselSessionService
+                .addCounselSession(addCounselSessionReq);
 
-                CommonRes<AddCounselSessionRes> commonRes = new CommonRes<>(addCounselSessionRes);
-                return ResponseEntity.ok(commonRes);
+        CommonRes<AddCounselSessionRes> commonRes = new CommonRes<>(addCounselSessionRes);
+        return ResponseEntity.ok(commonRes);
 
-        }
+    }
 
-        @GetMapping("/sessions/dates")
-        @Operation(summary = "특정 연월의 상담 세션이 있는 날짜 목록 조회")
-        @RoleSecured({ RoleType.ROLE_ADMIN, RoleType.ROLE_USER })
-        public ResponseEntity<CommonRes<List<LocalDate>>> getSessionDatesByYearAndMonth(
-                        @RequestParam int year,
-                        @RequestParam int month) {
-                List<LocalDate> dates = counselSessionService.getSessionDatesByYearAndMonth(year, month);
-                return ResponseEntity.ok(new CommonRes<>(dates));
-        }
+    @GetMapping("/sessions/dates")
+    @Operation(summary = "특정 연월의 상담 세션이 있는 날짜 목록 조회")
+    @RoleSecured({RoleType.ROLE_ADMIN, RoleType.ROLE_USER})
+    public ResponseEntity<CommonRes<List<LocalDate>>> getSessionDatesByYearAndMonth(
+            @RequestParam @Min(value = 1900, message = "연도는 1900년 이상이어야 합니다")
+            @Max(value = 9999, message = "연도는 9999년 이하여야 합니다") int year,
+            @RequestParam @Min(value = 1, message = "월은 1 이상이어야 합니다")
+            @Max(value = 12, message = "월은 12 이하여야 합니다") int month) {
+        List<LocalDate> dates = counselSessionService.getSessionDatesByYearAndMonth(year, month);
+        return ResponseEntity.ok(new CommonRes<>(dates));
+    }
 
-        @GetMapping("/sessions/stats")
-        @Operation(summary = "상담 세션 통계 조회")
-        @RoleSecured({ RoleType.ROLE_ADMIN, RoleType.ROLE_USER, RoleType.ROLE_ASSISTANT })
-        public ResponseEntity<CommonRes<CounselSessionStatRes>> getSessionStats() {
-                CounselSessionStatRes stats = counselSessionService.getSessionStats();
-                return ResponseEntity.ok(new CommonRes<>(stats));
-        }
+    @GetMapping("/sessions/stats")
+    @Operation(summary = "상담 세션 통계 조회")
+    @RoleSecured({RoleType.ROLE_ADMIN, RoleType.ROLE_USER, RoleType.ROLE_ASSISTANT})
+    public ResponseEntity<CommonRes<CounselSessionStatRes>> getSessionStats() {
+        CounselSessionStatRes stats = counselSessionService.getSessionStats();
+        return ResponseEntity.ok(new CommonRes<>(stats));
+    }
 
-        @GetMapping("/list")
-        @Operation(summary = "상담일정 목록 조회", tags = { "로그인/홈" })
-        @RoleSecured({ RoleType.ROLE_ASSISTANT, RoleType.ROLE_ADMIN, RoleType.ROLE_USER })
-        public ResponseEntity<CommonCursorRes<List<SelectCounselSessionListItem>>> selectCounselSessionListByBaseDateAndCursorAndSize(
-                        @RequestParam(required = false) LocalDate baseDate,
-                        @RequestParam(required = false) String cursor,
-                        @RequestParam(defaultValue = "15") int size) {
+    @GetMapping("/list")
+    @Operation(summary = "상담일정 목록 조회", tags = {"로그인/홈"})
+    @RoleSecured({RoleType.ROLE_ASSISTANT, RoleType.ROLE_ADMIN, RoleType.ROLE_USER})
+    public ResponseEntity<CommonCursorRes<List<SelectCounselSessionListItem>>> selectCounselSessionListByBaseDateAndCursorAndSize(
+            @RequestParam(required = false) LocalDate baseDate,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "15") int size) {
 
-                SelectCounselSessionListByBaseDateAndCursorAndSizeReq selectCounselSessionListByBaseDateAndCursorAndSizeReq = SelectCounselSessionListByBaseDateAndCursorAndSizeReq
-                                .builder()
-                                .baseDate(baseDate)
-                                .cursor(cursor)
-                                .size(size)
-                                .build();
+        SelectCounselSessionListByBaseDateAndCursorAndSizeReq selectCounselSessionListByBaseDateAndCursorAndSizeReq = SelectCounselSessionListByBaseDateAndCursorAndSizeReq
+                .builder()
+                .baseDate(baseDate)
+                .cursor(cursor)
+                .size(size)
+                .build();
 
-                SelectCounselSessionListByBaseDateAndCursorAndSizeRes selectCounselSessionListByBaseDateAndCursorAndSizeRes = counselSessionService
-                                .selectCounselSessionListByBaseDateAndCursorAndSize(
-                                                selectCounselSessionListByBaseDateAndCursorAndSizeReq);
+        SelectCounselSessionListByBaseDateAndCursorAndSizeRes selectCounselSessionListByBaseDateAndCursorAndSizeRes = counselSessionService
+                .selectCounselSessionListByBaseDateAndCursorAndSize(
+                        selectCounselSessionListByBaseDateAndCursorAndSizeReq);
 
-                return ResponseEntity.ok(new CommonCursorRes<>(
-                                selectCounselSessionListByBaseDateAndCursorAndSizeRes.sessionListItems(),
-                                selectCounselSessionListByBaseDateAndCursorAndSizeRes.nextCursor(),
-                                selectCounselSessionListByBaseDateAndCursorAndSizeRes.hasNext()));
-        }
+        return ResponseEntity.ok(new CommonCursorRes<>(
+                selectCounselSessionListByBaseDateAndCursorAndSizeRes.sessionListItems(),
+                selectCounselSessionListByBaseDateAndCursorAndSizeRes.nextCursor(),
+                selectCounselSessionListByBaseDateAndCursorAndSizeRes.hasNext()));
+    }
 
-        @GetMapping("/{counselSessionId}")
-        @Operation(summary = "상담일정 조회", tags = { "관리자 화면" })
-        public ResponseEntity<CommonRes<SelectCounselSessionRes>> selectCounselSession(
-                        @PathVariable String counselSessionId) {
+    @GetMapping("/{counselSessionId}")
+    @Operation(summary = "상담일정 조회", tags = {"관리자 화면"})
+    public ResponseEntity<CommonRes<SelectCounselSessionRes>> selectCounselSession(
+            @PathVariable String counselSessionId) {
 
-                SelectCounselSessionRes selectCounselSessionRes = counselSessionService
-                                .selectCounselSession(counselSessionId);
+        SelectCounselSessionRes selectCounselSessionRes = counselSessionService
+                .selectCounselSession(counselSessionId);
 
-                return ResponseEntity.ok(new CommonRes<>(selectCounselSessionRes));
+        return ResponseEntity.ok(new CommonRes<>(selectCounselSessionRes));
 
-        }
+    }
 
-        @PutMapping
-        @Operation(summary = "상담일정 수정", tags = { "관리자 화면" })
-        @RoleSecured(RoleType.ROLE_ADMIN)
-        public ResponseEntity<CommonRes<UpdateCounselSessionRes>> updateCounselSession(
-                        @RequestBody @Valid UpdateCounselSessionReq updateCounselSessionReq) {
+    @PutMapping
+    @Operation(summary = "상담일정 수정", tags = {"관리자 화면"})
+    @RoleSecured(RoleType.ROLE_ADMIN)
+    public ResponseEntity<CommonRes<UpdateCounselSessionRes>> updateCounselSession(
+            @RequestBody @Valid UpdateCounselSessionReq updateCounselSessionReq) {
 
-                UpdateCounselSessionRes updateCounselSessionRes = counselSessionService
-                                .updateCounselSession(updateCounselSessionReq);
+        UpdateCounselSessionRes updateCounselSessionRes = counselSessionService
+                .updateCounselSession(updateCounselSessionReq);
 
-                return ResponseEntity.ok(new CommonRes<>(updateCounselSessionRes));
-        }
+        return ResponseEntity.ok(new CommonRes<>(updateCounselSessionRes));
+    }
 
-        @PutMapping("/counselor")
-        @Operation(summary = "상담일정 담당 약사 수정", tags = {
-                        "로그인/홈" }, description = "req body에 counselorId 넣지 않은 경우 로그인 계정 정보로 할당됨. ")
-        @RoleSecured({ RoleType.ROLE_ADMIN, RoleType.ROLE_USER })
-        public ResponseEntity<CommonRes<UpdateCounselorInCounselSessionRes>> updateCounselorInCounselSession(
-                        @RequestBody @Valid UpdateCounselorInCounselSessionReq updateCounselorInCounselSessionReq) {
+    @PutMapping("/counselor")
+    @Operation(summary = "상담일정 담당 약사 수정", tags = {
+            "로그인/홈"}, description = "req body에 counselorId 넣지 않은 경우 로그인 계정 정보로 할당됨. ")
+    @RoleSecured({RoleType.ROLE_ADMIN, RoleType.ROLE_USER})
+    public ResponseEntity<CommonRes<UpdateCounselorInCounselSessionRes>> updateCounselorInCounselSession(
+            @RequestBody @Valid UpdateCounselorInCounselSessionReq updateCounselorInCounselSessionReq) {
 
-                UpdateCounselorInCounselSessionRes updateCounselorInCounselSessionRes = counselSessionService
-                                .updateCounselorInCounselSession(
-                                                updateCounselorInCounselSessionReq);
+        UpdateCounselorInCounselSessionRes updateCounselorInCounselSessionRes = counselSessionService
+                .updateCounselorInCounselSession(
+                        updateCounselorInCounselSessionReq);
 
-                return ResponseEntity.ok(new CommonRes<>(updateCounselorInCounselSessionRes));
+        return ResponseEntity.ok(new CommonRes<>(updateCounselorInCounselSessionRes));
 
-        }
+    }
 
-        @PutMapping("/status")
-        @Operation(summary = "상담 상태 수정", tags = { "로그인/홈" })
-        @RoleSecured({ RoleType.ROLE_ADMIN, RoleType.ROLE_USER })
-        public ResponseEntity<CommonRes<UpdateStatusInCounselSessionRes>> updateStatusInCounselSession(
-                        @RequestBody @Valid UpdateStatusInCounselSessionReq updateStatusInCounselSessionReq) {
-                UpdateStatusInCounselSessionRes updateStatusInCounselSessionRes = counselSessionService
-                                .updateStatusInCounselSession(updateStatusInCounselSessionReq);
+    @PutMapping("/status")
+    @Operation(summary = "상담 상태 수정", tags = {"로그인/홈"})
+    @RoleSecured({RoleType.ROLE_ADMIN, RoleType.ROLE_USER})
+    public ResponseEntity<CommonRes<UpdateStatusInCounselSessionRes>> updateStatusInCounselSession(
+            @RequestBody @Valid UpdateStatusInCounselSessionReq updateStatusInCounselSessionReq) {
+        UpdateStatusInCounselSessionRes updateStatusInCounselSessionRes = counselSessionService
+                .updateStatusInCounselSession(updateStatusInCounselSessionReq);
 
-                return ResponseEntity.ok(new CommonRes<>(updateStatusInCounselSessionRes));
+        return ResponseEntity.ok(new CommonRes<>(updateStatusInCounselSessionRes));
 
-        }
+    }
 
-        @DeleteMapping
-        @Operation(summary = "상담일정 삭제", tags = { "관리자 화면" })
-        @RoleSecured(RoleType.ROLE_ADMIN)
-        public ResponseEntity<CommonRes<DeleteCounselSessionRes>> deleteCounselSession(
-                        @RequestBody @Valid DeleteCounselSessionReq deleteCounselSessionReq) {
+    @DeleteMapping
+    @Operation(summary = "상담일정 삭제", tags = {"관리자 화면"})
+    @RoleSecured(RoleType.ROLE_ADMIN)
+    public ResponseEntity<CommonRes<DeleteCounselSessionRes>> deleteCounselSession(
+            @RequestBody @Valid DeleteCounselSessionReq deleteCounselSessionReq) {
 
-                DeleteCounselSessionRes deleteCounselSessionRes = counselSessionService
-                                .deleteCounselSessionRes(deleteCounselSessionReq);
-                return ResponseEntity.ok(new CommonRes<>(deleteCounselSessionRes));
+        DeleteCounselSessionRes deleteCounselSessionRes = counselSessionService
+                .deleteCounselSessionRes(deleteCounselSessionReq);
+        return ResponseEntity.ok(new CommonRes<>(deleteCounselSessionRes));
 
-        }
+    }
 
-        @GetMapping("/{counselSessionId}/previous/list")
-        @Operation(summary = "이전 상담 내역 조회", tags = { "본상담 - 이전 상담 내역" })
-        @RoleSecured(RoleType.ROLE_ADMIN)
-        public ResponseEntity<CommonRes<List<SelectPreviousCounselSessionListRes>>> selectPreviousCounselSessionList(
-                        @PathVariable("counselSessionId") String counselSessionId) {
+    @GetMapping("/{counselSessionId}/previous/list")
+    @Operation(summary = "이전 상담 내역 조회", tags = {"본상담 - 이전 상담 내역"})
+    @RoleSecured(RoleType.ROLE_ADMIN)
+    public ResponseEntity<CommonRes<List<SelectPreviousCounselSessionListRes>>> selectPreviousCounselSessionList(
+            @PathVariable("counselSessionId") String counselSessionId) {
 
-                List<SelectPreviousCounselSessionListRes> selectPreviousListByCounselSessionIdResList = counselSessionService
-                                .selectPreviousCounselSessionList(counselSessionId);
+        List<SelectPreviousCounselSessionListRes> selectPreviousListByCounselSessionIdResList = counselSessionService
+                .selectPreviousCounselSessionList(counselSessionId);
 
-                return ResponseEntity.ok(new CommonRes<>(selectPreviousListByCounselSessionIdResList));
+        return ResponseEntity.ok(new CommonRes<>(selectPreviousListByCounselSessionIdResList));
 
-        }
+    }
 
 }

--- a/src/main/java/com/springboot/api/controller/CounselSessionController.java
+++ b/src/main/java/com/springboot/api/controller/CounselSessionController.java
@@ -73,14 +73,8 @@ public class CounselSessionController {
                 .size(size)
                 .build();
 
-        SelectCounselSessionListByBaseDateAndCursorAndSizeRes selectCounselSessionListByBaseDateAndCursorAndSizeRes = counselSessionService
-                .selectCounselSessionListByBaseDateAndCursorAndSize(
-                        selectCounselSessionListByBaseDateAndCursorAndSizeReq);
-
-        return ResponseEntity.ok(new CommonCursorRes<>(
-                selectCounselSessionListByBaseDateAndCursorAndSizeRes.sessionListItems(),
-                selectCounselSessionListByBaseDateAndCursorAndSizeRes.nextCursor(),
-                selectCounselSessionListByBaseDateAndCursorAndSizeRes.hasNext()));
+        return ResponseEntity.ok(counselSessionService.selectCounselSessionListByBaseDateAndCursorAndSize(
+                selectCounselSessionListByBaseDateAndCursorAndSizeReq));
     }
 
     @GetMapping("/{counselSessionId}")

--- a/src/main/java/com/springboot/api/dto/counselsession/SelectCounselSessionListByBaseDateAndCursorAndSizeRes.java
+++ b/src/main/java/com/springboot/api/dto/counselsession/SelectCounselSessionListByBaseDateAndCursorAndSizeRes.java
@@ -1,5 +1,0 @@
-package com.springboot.api.dto.counselsession;
-
-import java.util.List;
-
-public record SelectCounselSessionListByBaseDateAndCursorAndSizeRes(List<SelectCounselSessionListItem> sessionListItems, String nextCursor, boolean hasNext){}

--- a/src/main/java/com/springboot/api/dto/counselsession/SelectCounselSessionListItem.java
+++ b/src/main/java/com/springboot/api/dto/counselsession/SelectCounselSessionListItem.java
@@ -1,14 +1,18 @@
 package com.springboot.api.dto.counselsession;
 
 
+import com.springboot.api.domain.*;
 import com.springboot.enums.CardRecordStatus;
 import com.springboot.enums.ScheduleStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Getter
 @Builder
 @AllArgsConstructor
 public class SelectCounselSessionListItem {
@@ -24,4 +28,33 @@ public class SelectCounselSessionListItem {
     @Schema(description = "상담 카드 기록 상태(UNRECORDED, RECORDING, RECORDED", example = "UNRECORDED")
     private CardRecordStatus cardRecordStatus;
     private boolean isCounselorAssign;
+
+    public static SelectCounselSessionListItem from(CounselSession counselSession) {
+
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        return SelectCounselSessionListItem
+                .builder()
+                .counseleeId(Optional.ofNullable(counselSession.getCounselee())
+                        .map(BaseEntity::getId)
+                        .orElse(""))
+                .counselorName(Optional.ofNullable(counselSession.getCounselor())
+                        .map(Counselor::getName)
+                        .orElse(""))
+                .counselorId(Optional.ofNullable(counselSession.getCounselor())
+                        .map(Counselor::getId)
+                        .orElse(""))
+                .counseleeName(Optional.ofNullable(counselSession.getCounselee())
+                        .map(Counselee::getName)
+                        .orElse(""))
+                .scheduledDate(counselSession.getScheduledStartDateTime().toLocalDate().toString())
+                .scheduledTime(counselSession.getScheduledStartDateTime().toLocalTime().format(timeFormatter))
+                .counselSessionId(counselSession.getId())
+                .isCounselorAssign(Optional.ofNullable(counselSession.getCounselor()).isPresent())
+                .status(counselSession.getStatus())
+                .cardRecordStatus(Optional.ofNullable(counselSession.getCounselCard())
+                        .map(CounselCard::getCardRecordStatus)
+                        .orElse(CardRecordStatus.UNRECORDED))
+                .build();
+    }
 }

--- a/src/main/java/com/springboot/api/dto/counselsession/SelectCounselSessionRes.java
+++ b/src/main/java/com/springboot/api/dto/counselsession/SelectCounselSessionRes.java
@@ -1,10 +1,17 @@
 package com.springboot.api.dto.counselsession;
 
 
+import com.springboot.api.domain.CounselSession;
+import com.springboot.api.domain.Counselee;
+import com.springboot.api.domain.Counselor;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor
 @Builder
 public class SelectCounselSessionRes {
 
@@ -21,5 +28,26 @@ public class SelectCounselSessionRes {
     private String counselorId;
 
     private String counselorName;
+
+    public static SelectCounselSessionRes from(CounselSession counselSession) {
+        return SelectCounselSessionRes
+                .builder()
+                .counselSessionId(counselSession.getId())
+                .scheduledTime(counselSession.getScheduledStartDateTime().toLocalDate().toString())
+                .scheduledDate(counselSession.getScheduledStartDateTime().toLocalTime().toString())
+                .counseleeId(Optional.ofNullable(counselSession.getCounselee())
+                        .map(Counselee::getId)
+                        .orElse(""))
+                .counseleeName(Optional.ofNullable(counselSession.getCounselee())
+                        .map(Counselee::getName)
+                        .orElse(""))
+                .counselorId(Optional.ofNullable(counselSession.getCounselor())
+                        .map(Counselor::getId)
+                        .orElse(""))
+                .counselorName(Optional.ofNullable(counselSession.getCounselor())
+                        .map(Counselor::getName)
+                        .orElse(""))
+                .build();
+    }
 
 }

--- a/src/main/java/com/springboot/api/repository/CounselSessionRepository.java
+++ b/src/main/java/com/springboot/api/repository/CounselSessionRepository.java
@@ -3,6 +3,8 @@ package com.springboot.api.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.springboot.api.domain.Counselee;
+import com.springboot.api.domain.Counselor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,49 +15,53 @@ import com.springboot.api.domain.CounselSession;
 import com.springboot.enums.ScheduleStatus;
 
 public interface CounselSessionRepository
-    extends JpaRepository<CounselSession, String>, CounselSessionRepositoryCustom {
+        extends JpaRepository<CounselSession, String>, CounselSessionRepositoryCustom {
 
-  @Override
-  void deleteById(@NonNull String id);
+    @Override
+    void deleteById(@NonNull String id);
 
-  @Query("""
-      SELECT cs FROM CounselSession cs
-      WHERE (cs.scheduledStartDateTime >= :startOfDay)
-        AND (cs.scheduledStartDateTime < :endOfDay)
-        AND (:cursorId IS NULL OR cs.id > :cursorId)
-        AND (:counselorId IS NULL OR cs.counselor.id = :counselorId)
-      ORDER BY cs.id ASC
-      """)
-  List<CounselSession> findByDateAndCursor(
-      @Param("startOfDay") LocalDateTime startOfDay,
-      @Param("endOfDay") LocalDateTime endOfDay,
-      @Param("cursorId") String cursorId,
-      @Param("counselorId") String counselorId,
-      Pageable pageable);
+    @Query("""
+            SELECT cs FROM CounselSession cs
+            WHERE (cs.scheduledStartDateTime >= :startOfDay)
+              AND (cs.scheduledStartDateTime < :endOfDay)
+              AND (:cursorId IS NULL OR cs.id > :cursorId)
+              AND (:counselorId IS NULL OR cs.counselor.id = :counselorId)
+            ORDER BY cs.id ASC
+            """)
+    List<CounselSession> findByDateAndCursor(
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay,
+            @Param("cursorId") String cursorId,
+            @Param("counselorId") String counselorId,
+            Pageable pageable);
 
-  @Query("""
-      SELECT cs FROM CounselSession cs
-      WHERE (:cursorId IS NULL OR cs.id > :cursorId)
-        AND (:counselorId IS NULL OR cs.counselor.id = :counselorId)
-      ORDER BY cs.id ASC
-      """)
-  List<CounselSession> findByCursor(
-      @Param("cursorId") String cursorId,
-      @Param("counselorId") String counselorId,
-      Pageable pageable);
+    @Query("""
+            SELECT cs FROM CounselSession cs
+            WHERE (:cursorId IS NULL OR cs.id > :cursorId)
+              AND (:counselorId IS NULL OR cs.counselor.id = :counselorId)
+            ORDER BY cs.id ASC
+            """)
+    List<CounselSession> findByCursor(
+            @Param("cursorId") String cursorId,
+            @Param("counselorId") String counselorId,
+            Pageable pageable);
 
-  @Query("""
-      SELECT cs FROM CounselSession cs
-      WHERE cs.counselee.id = :counseleeId
-       AND cs.id < :id
-      ORDER BY cs.id DESC
-      """)
-  List<CounselSession> findByCounseleeIdPrevious(
-      @Param("counseleeId") String counseleeId, @Param("id") String id, Pageable pageable);
+    @Query("""
+            SELECT cs FROM CounselSession cs
+            WHERE cs.counselee.id = :counseleeId
+             AND cs.id < :id
+            ORDER BY cs.id DESC
+            """)
+    List<CounselSession> findByCounseleeIdPrevious(
+            @Param("counseleeId") String counseleeId, @Param("id") String id, Pageable pageable);
 
-  List<CounselSession> findByCounseleeIdAndScheduledStartDateTimeLessThan(String counseleeId,
-      LocalDateTime scheduledStartDateTime);
+    List<CounselSession> findByCounseleeIdAndScheduledStartDateTimeLessThan(String counseleeId,
+                                                                            LocalDateTime scheduledStartDateTime);
 
-  List<CounselSession> findByStatusAndScheduledStartDateTimeBefore(ScheduleStatus status,
-      LocalDateTime dateTime);
+    List<CounselSession> findByStatusAndScheduledStartDateTimeBefore(ScheduleStatus status,
+                                                                     LocalDateTime dateTime);
+
+    boolean existsByCounselorAndScheduledStartDateTime(Counselor counselor, LocalDateTime scheduledStartDateTime);
+
+    boolean existsByCounseleeAndScheduledStartDateTime(Counselee counselee, LocalDateTime scheduledStartDateTime);
 }

--- a/src/main/java/com/springboot/api/repository/CounselSessionRepositoryCustom.java
+++ b/src/main/java/com/springboot/api/repository/CounselSessionRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.springboot.api.repository;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import com.springboot.api.domain.CounselSession;
 import com.springboot.enums.ScheduleStatus;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface CounselSessionRepositoryCustom {
     List<LocalDate> findDistinctDatesByYearAndMonth(int year, int month);
@@ -14,4 +14,6 @@ public interface CounselSessionRepositoryCustom {
     long countByStatus(ScheduleStatus status);
 
     long countDistinctCounseleeForCurrentMonth();
+
+    long cancelOverDueSessions();
 }

--- a/src/main/java/com/springboot/api/repository/CounselSessionRepositoryCustom.java
+++ b/src/main/java/com/springboot/api/repository/CounselSessionRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.springboot.api.repository;
 
 import com.springboot.api.domain.CounselSession;
 import com.springboot.enums.ScheduleStatus;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,6 +11,8 @@ public interface CounselSessionRepositoryCustom {
     List<LocalDate> findDistinctDatesByYearAndMonth(int year, int month);
 
     List<CounselSession> findCompletedSessionsByYearAndMonth(int year, int month);
+
+    List<CounselSession> findSessionByCursorAndDate(LocalDate date, String cursorId, String counselorId, Pageable pageable);
 
     long countByStatus(ScheduleStatus status);
 

--- a/src/main/java/com/springboot/api/repository/CounselSessionRepositoryImpl.java
+++ b/src/main/java/com/springboot/api/repository/CounselSessionRepositoryImpl.java
@@ -1,74 +1,86 @@
 package com.springboot.api.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.springboot.api.domain.CounselSession;
+import com.springboot.api.domain.QCounselSession;
+import com.springboot.enums.ScheduleStatus;
+import org.springframework.stereotype.Repository;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.stereotype.Repository;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.springboot.api.domain.CounselSession;
-import com.springboot.api.domain.QCounselSession;
-import com.springboot.enums.ScheduleStatus;
-
 @Repository
 public class CounselSessionRepositoryImpl implements CounselSessionRepositoryCustom {
 
-        private final JPAQueryFactory queryFactory;
-        private final QCounselSession counselSession = QCounselSession.counselSession;
+    private final JPAQueryFactory queryFactory;
+    private final QCounselSession counselSession = QCounselSession.counselSession;
 
-        public CounselSessionRepositoryImpl(JPAQueryFactory queryFactory) {
-                this.queryFactory = queryFactory;
-        }
+    public CounselSessionRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
 
-        @Override
-        public List<LocalDate> findDistinctDatesByYearAndMonth(int year, int month) {
-                return queryFactory
-                                .select(counselSession.scheduledStartDateTime)
-                                .from(counselSession)
-                                .where(
-                                                counselSession.scheduledStartDateTime.year().eq(year),
-                                                counselSession.scheduledStartDateTime.month().eq(month))
-                                .orderBy(counselSession.scheduledStartDateTime.asc())
-                                .fetch()
-                                .stream()
-                                .map(LocalDateTime::toLocalDate)
-                                .distinct()
-                                .collect(Collectors.toList());
-        }
+    @Override
+    public List<LocalDate> findDistinctDatesByYearAndMonth(int year, int month) {
+        return queryFactory
+                .select(counselSession.scheduledStartDateTime)
+                .from(counselSession)
+                .where(
+                        counselSession.scheduledStartDateTime.year().eq(year),
+                        counselSession.scheduledStartDateTime.month().eq(month))
+                .orderBy(counselSession.scheduledStartDateTime.asc())
+                .fetch()
+                .stream()
+                .map(LocalDateTime::toLocalDate)
+                .distinct()
+                .collect(Collectors.toList());
+    }
 
-        @Override
-        public List<CounselSession> findCompletedSessionsByYearAndMonth(int year, int month) {
-                return queryFactory
-                                .selectFrom(counselSession)
-                                .where(
-                                                counselSession.startDateTime.year().eq(year),
-                                                counselSession.startDateTime.month().eq(month),
-                                                counselSession.status.eq(ScheduleStatus.COMPLETED),
-                                                counselSession.startDateTime.isNotNull(),
-                                                counselSession.endDateTime.isNotNull())
-                                .fetch();
-        }
+    @Override
+    public List<CounselSession> findCompletedSessionsByYearAndMonth(int year, int month) {
+        return queryFactory
+                .selectFrom(counselSession)
+                .where(
+                        counselSession.startDateTime.year().eq(year),
+                        counselSession.startDateTime.month().eq(month),
+                        counselSession.status.eq(ScheduleStatus.COMPLETED),
+                        counselSession.startDateTime.isNotNull(),
+                        counselSession.endDateTime.isNotNull())
+                .fetch();
+    }
 
-        @Override
-        public long countByStatus(ScheduleStatus status) {
-                return queryFactory
-                                .select(counselSession.count())
-                                .from(counselSession)
-                                .where(counselSession.status.eq(status))
-                                .fetchOne();
-        }
+    @Override
+    public long countByStatus(ScheduleStatus status) {
+        return queryFactory
+                .select(counselSession.count())
+                .from(counselSession)
+                .where(counselSession.status.eq(status))
+                .fetchOne();
+    }
 
-        @Override
-        public long countDistinctCounseleeForCurrentMonth() {
-                LocalDate now = LocalDate.now();
-                return queryFactory
-                                .select(counselSession.counselee.countDistinct())
-                                .from(counselSession)
-                                .where(
-                                                counselSession.scheduledStartDateTime.year().eq(now.getYear()),
-                                                counselSession.scheduledStartDateTime.month().eq(now.getMonthValue()))
-                                .fetchOne();
-        }
+    @Override
+    public long countDistinctCounseleeForCurrentMonth() {
+        LocalDate now = LocalDate.now();
+        return queryFactory
+                .select(counselSession.counselee.countDistinct())
+                .from(counselSession)
+                .where(
+                        counselSession.scheduledStartDateTime.year().eq(now.getYear()),
+                        counselSession.scheduledStartDateTime.month().eq(now.getMonthValue()))
+                .fetchOne();
+    }
+
+    @Override
+    public long cancelOverDueSessions() {
+        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
+
+        return queryFactory
+                .update(counselSession)
+                .set(counselSession.status, ScheduleStatus.CANCELED)
+                .where(
+                        counselSession.status.eq(ScheduleStatus.SCHEDULED),
+                        counselSession.scheduledStartDateTime.before(twentyFourHoursAgo))
+                .execute();
+    }
 }

--- a/src/main/java/com/springboot/api/service/CounselSessionService.java
+++ b/src/main/java/com/springboot/api/service/CounselSessionService.java
@@ -153,12 +153,7 @@ public class CounselSessionService {
             Counselee counselee = counselSession.getCounselee();
             if (counselee != null) {
                 // 완료된 상담 세션 수 계산
-                long completedCount = counselee.getCounselSessions().stream()
-                        .filter(session -> ScheduleStatus.COMPLETED.equals(session.getStatus()))
-                        .count();
-
-                counselee.setCounselCount((int) completedCount);
-                counselee.setLastCounselDate(counselSession.getScheduledStartDateTime().toLocalDate());
+                counselee.counselSessionComplete(counselSession.getScheduledStartDateTime().toLocalDate());
             }
         }
 

--- a/src/main/java/com/springboot/api/service/CounselSessionService.java
+++ b/src/main/java/com/springboot/api/service/CounselSessionService.java
@@ -1,5 +1,25 @@
 package com.springboot.api.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.springboot.api.common.exception.NoContentException;
+import com.springboot.api.common.util.DateTimeUtil;
+import com.springboot.api.domain.*;
+import com.springboot.api.dto.counselsession.*;
+import com.springboot.api.repository.CounselSessionRepository;
+import com.springboot.api.repository.CounselorRepository;
+import com.springboot.enums.CardRecordStatus;
+import com.springboot.enums.ScheduleStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -8,368 +28,311 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.springboot.api.common.exception.NoContentException;
-import com.springboot.api.common.util.DateTimeUtil;
-import com.springboot.api.domain.BaseEntity;
-import com.springboot.api.domain.CounselCard;
-import com.springboot.api.domain.CounselSession;
-import com.springboot.api.domain.Counselee;
-import com.springboot.api.domain.Counselor;
-import com.springboot.api.dto.counselsession.AddCounselSessionReq;
-import com.springboot.api.dto.counselsession.AddCounselSessionRes;
-import com.springboot.api.dto.counselsession.CounselSessionStatRes;
-import com.springboot.api.dto.counselsession.DeleteCounselSessionReq;
-import com.springboot.api.dto.counselsession.DeleteCounselSessionRes;
-import com.springboot.api.dto.counselsession.SelectCounselSessionListByBaseDateAndCursorAndSizeReq;
-import com.springboot.api.dto.counselsession.SelectCounselSessionListByBaseDateAndCursorAndSizeRes;
-import com.springboot.api.dto.counselsession.SelectCounselSessionListItem;
-import com.springboot.api.dto.counselsession.SelectCounselSessionRes;
-import com.springboot.api.dto.counselsession.SelectPreviousCounselSessionListRes;
-import com.springboot.api.dto.counselsession.UpdateCounselSessionReq;
-import com.springboot.api.dto.counselsession.UpdateCounselSessionRes;
-import com.springboot.api.dto.counselsession.UpdateCounselorInCounselSessionReq;
-import com.springboot.api.dto.counselsession.UpdateCounselorInCounselSessionRes;
-import com.springboot.api.dto.counselsession.UpdateStatusInCounselSessionReq;
-import com.springboot.api.dto.counselsession.UpdateStatusInCounselSessionRes;
-import com.springboot.api.repository.CounselSessionRepository;
-import com.springboot.api.repository.CounselorRepository;
-import com.springboot.enums.CardRecordStatus;
-import com.springboot.enums.ScheduleStatus;
-
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class CounselSessionService {
 
-        private final EntityManager entityManager;
-        private final DateTimeUtil dateTimeUtil;
-        private final CounselSessionRepository counselSessionRepository;
-        private final CounselorRepository counselorRepository;
+    private final EntityManager entityManager;
+    private final DateTimeUtil dateTimeUtil;
+    private final CounselSessionRepository counselSessionRepository;
+    private final CounselorRepository counselorRepository;
 
-        @CacheEvict(value = { "sessionDates", "sessionStats", "sessionList" }, allEntries = true)
-        @Transactional
-        public AddCounselSessionRes addCounselSession(AddCounselSessionReq addCounselSessionReq) {
-                Counselor proxyCounselor = entityManager.getReference(Counselor.class,
-                                addCounselSessionReq.getCounselorId());
-                Counselee proxyCounselee = entityManager.getReference(Counselee.class,
-                                addCounselSessionReq.getCounseleeId());
+    @CacheEvict(value = {"sessionDates", "sessionStats", "sessionList"}, allEntries = true)
+    @Transactional
+    public AddCounselSessionRes addCounselSession(AddCounselSessionReq addCounselSessionReq) {
+        Counselor proxyCounselor = entityManager.getReference(Counselor.class,
+                addCounselSessionReq.getCounselorId());
+        Counselee proxyCounselee = entityManager.getReference(Counselee.class,
+                addCounselSessionReq.getCounseleeId());
 
-                CounselSession counselSession = CounselSession.builder()
-                                .counselor(proxyCounselor)
-                                .counselee(proxyCounselee)
-                                .scheduledStartDateTime(dateTimeUtil
-                                                .parseToDateTime(addCounselSessionReq.getScheduledStartDateTime()))
-                                .status(addCounselSessionReq.getStatus())
-                                .build();
+        CounselSession counselSession = CounselSession.builder()
+                .counselor(proxyCounselor)
+                .counselee(proxyCounselee)
+                .scheduledStartDateTime(dateTimeUtil
+                        .parseToDateTime(addCounselSessionReq.getScheduledStartDateTime()))
+                .status(addCounselSessionReq.getStatus())
+                .build();
 
-                CounselSession savedCounselSession = counselSessionRepository.save(counselSession);
+        CounselSession savedCounselSession = counselSessionRepository.save(counselSession);
 
-                return new AddCounselSessionRes(savedCounselSession.getId());
+        return new AddCounselSessionRes(savedCounselSession.getId());
+    }
+
+    public SelectCounselSessionRes selectCounselSession(String id) {
+        CounselSession counselSession = counselSessionRepository.findById(id).orElseThrow(
+                IllegalArgumentException::new);
+
+        return SelectCounselSessionRes
+                .builder()
+                .counselSessionId(counselSession.getId())
+                .scheduledTime(counselSession.getScheduledStartDateTime().toLocalDate().toString())
+                .scheduledDate(counselSession.getScheduledStartDateTime().toLocalTime().toString())
+                .counseleeId(Optional.ofNullable(counselSession.getCounselee())
+                        .map(Counselee::getId)
+                        .orElse(""))
+                .counseleeName(Optional.ofNullable(counselSession.getCounselee())
+                        .map(Counselee::getName)
+                        .orElse(""))
+                .counselorId(Optional.ofNullable(counselSession.getCounselor())
+                        .map(Counselor::getId)
+                        .orElse(""))
+                .counselorName(Optional.ofNullable(counselSession.getCounselor())
+                        .map(Counselor::getName)
+                        .orElse(""))
+                .build();
+
+    }
+
+    @Cacheable(value = "sessionList", key = "#req.baseDate + '-' + #req.cursor + '-' + #req.size")
+    @Transactional
+    public SelectCounselSessionListByBaseDateAndCursorAndSizeRes selectCounselSessionListByBaseDateAndCursorAndSize(
+            SelectCounselSessionListByBaseDateAndCursorAndSizeReq req) {
+        Pageable pageable = PageRequest.of(0, req.getSize());
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        List<CounselSession> sessions;
+
+        LocalDateTime startOfDay = Optional
+                .ofNullable(req.getBaseDate())
+                .map(LocalDate::atStartOfDay)
+                .orElse(null);
+
+        LocalDateTime endOfDay = Optional
+                .ofNullable(req.getBaseDate())
+                .map(d -> d.plusDays(1))
+                .map(LocalDate::atStartOfDay)
+                .orElse(null);
+
+        if (req.getBaseDate() == null) {
+            sessions = counselSessionRepository.findByCursor(
+                    req.getCursor(),
+                    null,
+                    pageable);
+        } else {
+            sessions = counselSessionRepository.findByDateAndCursor(
+                    req.getBaseDate()
+                            .atStartOfDay(),
+                    Optional.of(req.getBaseDate()
+                            .atStartOfDay()).map(d -> d.plusDays(1)).get(),
+                    req.getCursor(),
+                    null,
+                    pageable);
         }
 
-        public SelectCounselSessionRes selectCounselSession(String id) {
-                CounselSession counselSession = counselSessionRepository.findById(id).orElseThrow(
-                                IllegalArgumentException::new);
+        String nextCursorId = null;
 
-                return SelectCounselSessionRes
-                                .builder()
-                                .counselSessionId(counselSession.getId())
-                                .scheduledTime(counselSession.getScheduledStartDateTime().toLocalDate().toString())
-                                .scheduledDate(counselSession.getScheduledStartDateTime().toLocalTime().toString())
-                                .counseleeId(Optional.ofNullable(counselSession.getCounselee())
-                                                .map(Counselee::getId)
-                                                .orElse(""))
-                                .counseleeName(Optional.ofNullable(counselSession.getCounselee())
-                                                .map(Counselee::getName)
-                                                .orElse(""))
-                                .counselorId(Optional.ofNullable(counselSession.getCounselor())
-                                                .map(Counselor::getId)
-                                                .orElse(""))
-                                .counselorName(Optional.ofNullable(counselSession.getCounselor())
-                                                .map(Counselor::getName)
-                                                .orElse(""))
-                                .build();
-
+        if (!sessions.isEmpty()) {
+            CounselSession lastSession = sessions.getLast();
+            nextCursorId = lastSession.getId();
         }
 
-        @Cacheable(value = "sessionList", key = "#req.baseDate + '-' + #req.cursor + '-' + #req.size")
-        @Transactional
-        public SelectCounselSessionListByBaseDateAndCursorAndSizeRes selectCounselSessionListByBaseDateAndCursorAndSize(
-                        SelectCounselSessionListByBaseDateAndCursorAndSizeReq req) {
-                Pageable pageable = PageRequest.of(0, req.getSize());
-                DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+        // hasNext 계산
+        boolean hasNext = sessions.size() == req.getSize();
 
-                List<CounselSession> sessions;
+        List<SelectCounselSessionListItem> sessionListItems = sessions.stream()
+                .map(s -> SelectCounselSessionListItem.builder()
+                        .counseleeId(Optional.ofNullable(s.getCounselee())
+                                .map(BaseEntity::getId)
+                                .orElse(""))
+                        .counselorName(Optional.ofNullable(s.getCounselor())
+                                .map(Counselor::getName)
+                                .orElse(""))
+                        .counselorId(Optional.ofNullable(s.getCounselor())
+                                .map(Counselor::getId)
+                                .orElse(""))
+                        .counseleeName(Optional.ofNullable(s.getCounselee())
+                                .map(Counselee::getName)
+                                .orElse(""))
+                        .scheduledDate(s.getScheduledStartDateTime().toLocalDate().toString())
+                        .scheduledTime(s.getScheduledStartDateTime().toLocalTime()
+                                .format(timeFormatter))
+                        .counselSessionId(s.getId())
+                        .isCounselorAssign(Optional.ofNullable(s.getCounselor()).isPresent())
+                        .status(s.getStatus())
+                        .cardRecordStatus(Optional.ofNullable(s.getCounselCard())
+                                .map(CounselCard::getCardRecordStatus)
+                                .orElse(CardRecordStatus.UNRECORDED))
+                        .build())
+                .toList();
 
-                LocalDateTime startOfDay = Optional
-                                .ofNullable(req.getBaseDate())
-                                .map(LocalDate::atStartOfDay)
-                                .orElse(null);
-
-                LocalDateTime endOfDay = Optional
-                                .ofNullable(req.getBaseDate())
-                                .map(d -> d.plusDays(1))
-                                .map(LocalDate::atStartOfDay)
-                                .orElse(null);
-
-                if (req.getBaseDate() == null) {
-                        sessions = counselSessionRepository.findByCursor(
-                                        req.getCursor(),
-                                        null,
-                                        pageable);
-                } else {
-                        sessions = counselSessionRepository.findByDateAndCursor(
-                                        req.getBaseDate()
-                                                        .atStartOfDay(),
-                                        Optional.of(req.getBaseDate()
-                                                        .atStartOfDay()).map(d -> d.plusDays(1)).get(),
-                                        req.getCursor(),
-                                        null,
-                                        pageable);
-                }
-
-                String nextCursorId = null;
-
-                if (!sessions.isEmpty()) {
-                        CounselSession lastSession = sessions.getLast();
-                        nextCursorId = lastSession.getId();
-                }
-
-                // hasNext 계산
-                boolean hasNext = sessions.size() == req.getSize();
-
-                List<SelectCounselSessionListItem> sessionListItems = sessions.stream()
-                                .map(s -> SelectCounselSessionListItem.builder()
-                                                .counseleeId(Optional.ofNullable(s.getCounselee())
-                                                                .map(BaseEntity::getId)
-                                                                .orElse(""))
-                                                .counselorName(Optional.ofNullable(s.getCounselor())
-                                                                .map(Counselor::getName)
-                                                                .orElse(""))
-                                                .counselorId(Optional.ofNullable(s.getCounselor())
-                                                                .map(Counselor::getId)
-                                                                .orElse(""))
-                                                .counseleeName(Optional.ofNullable(s.getCounselee())
-                                                                .map(Counselee::getName)
-                                                                .orElse(""))
-                                                .scheduledDate(s.getScheduledStartDateTime().toLocalDate().toString())
-                                                .scheduledTime(s.getScheduledStartDateTime().toLocalTime()
-                                                                .format(timeFormatter))
-                                                .counselSessionId(s.getId())
-                                                .isCounselorAssign(Optional.ofNullable(s.getCounselor()).isPresent())
-                                                .status(s.getStatus())
-                                                .cardRecordStatus(Optional.ofNullable(s.getCounselCard())
-                                                                .map(CounselCard::getCardRecordStatus)
-                                                                .orElse(CardRecordStatus.UNRECORDED))
-                                                .build())
-                                .toList();
-
-                if (sessionListItems.isEmpty()) {
-                        throw new NoContentException();
-                }
-
-                return new SelectCounselSessionListByBaseDateAndCursorAndSizeRes(sessionListItems, nextCursorId,
-                                hasNext);
+        if (sessionListItems.isEmpty()) {
+            throw new NoContentException();
         }
 
-        @CacheEvict(value = { "sessionDates", "sessionStats", "sessionList" }, allEntries = true)
-        @Transactional
-        public UpdateCounselSessionRes updateCounselSession(UpdateCounselSessionReq updateCounselSessionReq) {
-                CounselSession counselSession = counselSessionRepository
-                                .findById(updateCounselSessionReq.getCounselSessionId()).orElseThrow(
-                                                NoContentException::new);
+        return new SelectCounselSessionListByBaseDateAndCursorAndSizeRes(sessionListItems, nextCursorId,
+                hasNext);
+    }
 
-                Counselor proxyCounselor = entityManager.getReference(Counselor.class,
-                                updateCounselSessionReq.getCounselorId());
-                Counselee proxyCounselee = entityManager.getReference(Counselee.class,
-                                updateCounselSessionReq.getCounseleeId());
-                counselSession.setScheduledStartDateTime(dateTimeUtil
-                                .parseToDateTime(updateCounselSessionReq.getScheduledStartDateTime()));
-                counselSession.setCounselor(proxyCounselor);
-                counselSession.setCounselee(proxyCounselee);
+    @CacheEvict(value = {"sessionDates", "sessionStats", "sessionList"}, allEntries = true)
+    @Transactional
+    public UpdateCounselSessionRes updateCounselSession(UpdateCounselSessionReq updateCounselSessionReq) {
+        CounselSession counselSession = counselSessionRepository
+                .findById(updateCounselSessionReq.getCounselSessionId()).orElseThrow(
+                        NoContentException::new);
 
-                return new UpdateCounselSessionRes(updateCounselSessionReq.getCounselSessionId());
+        Counselor proxyCounselor = entityManager.getReference(Counselor.class,
+                updateCounselSessionReq.getCounselorId());
+        Counselee proxyCounselee = entityManager.getReference(Counselee.class,
+                updateCounselSessionReq.getCounseleeId());
+        counselSession.setScheduledStartDateTime(dateTimeUtil
+                .parseToDateTime(updateCounselSessionReq.getScheduledStartDateTime()));
+        counselSession.setCounselor(proxyCounselor);
+        counselSession.setCounselee(proxyCounselee);
+
+        return new UpdateCounselSessionRes(updateCounselSessionReq.getCounselSessionId());
+    }
+
+    @CacheEvict(value = {"sessionList"}, allEntries = true)
+    @Transactional
+    public UpdateCounselorInCounselSessionRes updateCounselorInCounselSession(
+            UpdateCounselorInCounselSessionReq updateCounselorInCounselSessionReq) {
+        CounselSession counselSession = counselSessionRepository
+                .findById(updateCounselorInCounselSessionReq.counselSessionId())
+                .orElseThrow(NoContentException::new);
+
+        String counselorId = updateCounselorInCounselSessionReq.counselorId();
+        Counselor counselor = counselorRepository.findById(counselorId)
+                .orElseThrow(NoContentException::new);
+
+        counselSession.setCounselor(counselor);
+
+        return new UpdateCounselorInCounselSessionRes(counselSession.getId());
+    }
+
+    @CacheEvict(value = {"sessionStats", "sessionList"}, allEntries = true)
+    @Transactional
+    public UpdateStatusInCounselSessionRes updateStatusInCounselSession(
+            UpdateStatusInCounselSessionReq updateStatusInCounselSessionReq) {
+
+        CounselSession counselSession = counselSessionRepository
+                .findById(updateStatusInCounselSessionReq.counselSessionId())
+                .orElseThrow(NoContentException::new);
+
+        counselSession.setStatus(updateStatusInCounselSessionReq.status());
+        if (ScheduleStatus.COMPLETED.equals(updateStatusInCounselSessionReq.status())) {
+            Counselee counselee = counselSession.getCounselee();
+            if (counselee != null) {
+                // 완료된 상담 세션 수 계산
+                long completedCount = counselee.getCounselSessions().stream()
+                        .filter(session -> ScheduleStatus.COMPLETED.equals(session.getStatus()))
+                        .count();
+
+                counselee.setCounselCount((int) completedCount);
+                counselee.setLastCounselDate(counselSession.getScheduledStartDateTime().toLocalDate());
+            }
         }
 
-        @CacheEvict(value = { "sessionList" }, allEntries = true)
-        @Transactional
-        public UpdateCounselorInCounselSessionRes updateCounselorInCounselSession(
-                        UpdateCounselorInCounselSessionReq updateCounselorInCounselSessionReq) {
-                CounselSession counselSession = counselSessionRepository
-                                .findById(updateCounselorInCounselSessionReq.counselSessionId())
-                                .orElseThrow(NoContentException::new);
+        return new UpdateStatusInCounselSessionRes(counselSession.getId());
+    }
 
-                String counselorId = updateCounselorInCounselSessionReq.counselorId();
-                Counselor counselor = counselorRepository.findById(counselorId)
-                                .orElseThrow(NoContentException::new);
+    @CacheEvict(value = {"sessionDates", "sessionStats", "sessionList"}, allEntries = true)
+    @Transactional
+    public DeleteCounselSessionRes deleteCounselSessionRes(DeleteCounselSessionReq deleteCounselSessionReq) {
 
-                counselSession.setCounselor(counselor);
+        counselSessionRepository.deleteById(deleteCounselSessionReq.getCounselSessionId());
 
-                return new UpdateCounselorInCounselSessionRes(counselSession.getId());
+        return new DeleteCounselSessionRes(deleteCounselSessionReq.getCounselSessionId());
+
+    }
+
+    public List<SelectPreviousCounselSessionListRes> selectPreviousCounselSessionList(String counselSessionId) {
+        CounselSession counselSession = counselSessionRepository.findById(counselSessionId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        Counselee counselee = Optional.ofNullable(counselSession.getCounselee())
+                .orElseThrow(NoContentException::new);
+
+        List<CounselSession> previousCounselSessions = counselSessionRepository
+                .findByCounseleeIdAndScheduledStartDateTimeLessThan(counselee.getId(),
+                        counselSession.getScheduledStartDateTime());
+
+        List<SelectPreviousCounselSessionListRes> selectPreviousCounselSessionListResList = previousCounselSessions
+                .stream()
+                .filter(session -> ScheduleStatus.COMPLETED.equals(session.getStatus()))
+                .sorted(Comparator.comparing(CounselSession::getEndDateTime).reversed())
+                .map(session -> {
+
+                    JsonNode baseInfo = session.getCounselCard().getBaseInformation()
+                            .get("baseInfo");
+                    return new SelectPreviousCounselSessionListRes(
+                            session.getId(),
+                            baseInfo.get("counselSessionOrder").asText(),
+                            session.getScheduledStartDateTime().toLocalDate(),
+                            session.getCounselor().getName(),
+                            false);
+                })
+                .toList();
+
+        if (selectPreviousCounselSessionListResList.isEmpty()) {
+            throw new NoContentException();
         }
 
-        @CacheEvict(value = { "sessionStats", "sessionList" }, allEntries = true)
-        @Transactional
-        public UpdateStatusInCounselSessionRes updateStatusInCounselSession(
-                        UpdateStatusInCounselSessionReq updateStatusInCounselSessionReq) {
+        return selectPreviousCounselSessionListResList;
 
-                CounselSession counselSession = counselSessionRepository
-                                .findById(updateStatusInCounselSessionReq.counselSessionId())
-                                .orElseThrow(NoContentException::new);
+    }
 
-                counselSession.setStatus(updateStatusInCounselSessionReq.status());
-                if (ScheduleStatus.COMPLETED.equals(updateStatusInCounselSessionReq.status())) {
-                        Counselee counselee = counselSession.getCounselee();
-                        if (counselee != null) {
-                                // 완료된 상담 세션 수 계산
-                                long completedCount = counselee.getCounselSessions().stream()
-                                                .filter(session -> ScheduleStatus.COMPLETED.equals(session.getStatus()))
-                                                .count();
-
-                                counselee.setCounselCount((int) completedCount);
-                                counselee.setLastCounselDate(counselSession.getScheduledStartDateTime().toLocalDate());
-                        }
-                }
-
-                return new UpdateStatusInCounselSessionRes(counselSession.getId());
+    @Cacheable(value = "sessionDates", key = "#year + '-' + #month")
+    public List<LocalDate> getSessionDatesByYearAndMonth(int year, int month) {
+        try {
+            return counselSessionRepository.findDistinctDatesByYearAndMonth(year, month);
+        } catch (Exception e) {
+            throw new RuntimeException("상담 일정 조회 중 오류가 발생했습니다", e);
         }
+    }
 
-        @CacheEvict(value = { "sessionDates", "sessionStats", "sessionList" }, allEntries = true)
-        @Transactional
-        public DeleteCounselSessionRes deleteCounselSessionRes(DeleteCounselSessionReq deleteCounselSessionReq) {
+    @Cacheable(value = "sessionStats")
+    @Transactional(readOnly = true)
+    public CounselSessionStatRes getSessionStats() {
+        try {
+            long totalSessionCount = calculateTotalSessionCount();
+            long counseleeCount = counselSessionRepository.countDistinctCounseleeForCurrentMonth();
+            long totalCaringMessageCount = counselSessionRepository.count();
+            double counselHours = calculateCounselHoursForThisMonth();
 
-                counselSessionRepository.deleteById(deleteCounselSessionReq.getCounselSessionId());
-
-                return new DeleteCounselSessionRes(deleteCounselSessionReq.getCounselSessionId());
-
+            return CounselSessionStatRes.builder()
+                    .totalSessionCount(totalSessionCount)
+                    .counseleeCountForThisMonth(counseleeCount)
+                    .totalCaringMessageCount(totalCaringMessageCount)
+                    .counselHoursForThisMonth((long) counselHours)
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("통계 정보 조회 중 오류가 발생했습니다", e);
         }
+    }
 
-        public List<SelectPreviousCounselSessionListRes> selectPreviousCounselSessionList(String counselSessionId) {
-                CounselSession counselSession = counselSessionRepository.findById(counselSessionId)
-                                .orElseThrow(IllegalArgumentException::new);
-
-                Counselee counselee = Optional.ofNullable(counselSession.getCounselee())
-                                .orElseThrow(NoContentException::new);
-
-                List<CounselSession> previousCounselSessions = counselSessionRepository
-                                .findByCounseleeIdAndScheduledStartDateTimeLessThan(counselee.getId(),
-                                                counselSession.getScheduledStartDateTime());
-
-                List<SelectPreviousCounselSessionListRes> selectPreviousCounselSessionListResList = previousCounselSessions
-                                .stream()
-                                .filter(session -> ScheduleStatus.COMPLETED.equals(session.getStatus()))
-                                .sorted(Comparator.comparing(CounselSession::getEndDateTime).reversed())
-                                .map(session -> {
-
-                                        JsonNode baseInfo = session.getCounselCard().getBaseInformation()
-                                                        .get("baseInfo");
-                                        return new SelectPreviousCounselSessionListRes(
-                                                        session.getId(),
-                                                        baseInfo.get("counselSessionOrder").asText(),
-                                                        session.getScheduledStartDateTime().toLocalDate(),
-                                                        session.getCounselor().getName(),
-                                                        false);
-                                })
-                                .toList();
-
-                if (selectPreviousCounselSessionListResList.isEmpty()) {
-                        throw new NoContentException();
-                }
-
-                return selectPreviousCounselSessionListResList;
-
+    private long calculateTotalSessionCount() {
+        try {
+            return counselSessionRepository.countByStatus(ScheduleStatus.COMPLETED);
+        } catch (Exception e) {
+            throw new RuntimeException("완료된 상담 세션 수 계산 중 오류 발생", e);
         }
+    }
 
-        @Cacheable(value = "sessionDates", key = "#year + '-' + #month")
-        public List<LocalDate> getSessionDatesByYearAndMonth(int year, int month) {
-                // 입력값 유효성 검사
-                if (month < 1 || month > 12) {
-                        throw new IllegalArgumentException("월은 1-12 사이여야 합니다");
-                }
-                if (year < 1900 || year > 9999) {
-                        throw new IllegalArgumentException("연도가 유효하지 않습니다");
-                }
+    private double calculateCounselHoursForThisMonth() {
+        try {
+            int year = LocalDateTime.now().getYear();
+            int month = LocalDateTime.now().getMonthValue();
+            List<CounselSession> completedSessions = counselSessionRepository
+                    .findCompletedSessionsByYearAndMonth(year, month);
 
-                try {
-                        return counselSessionRepository.findDistinctDatesByYearAndMonth(year, month);
-                } catch (Exception e) {
-                        throw new RuntimeException("상담 일정 조회 중 오류가 발생했습니다", e);
-                }
+            return completedSessions.stream()
+                    .mapToDouble(session -> {
+                        Duration duration = Duration.between(
+                                session.getStartDateTime(),
+                                session.getEndDateTime());
+                        return duration.toMinutes() / 60.0;
+                    })
+                    .sum();
+        } catch (Exception e) {
+            throw new RuntimeException("이번 달 상담 시간 계산 중 오류 발생", e);
         }
+    }
 
-        @Cacheable(value = "sessionStats")
-        public CounselSessionStatRes getSessionStats() {
-                try {
-                        long totalSessionCount = calculateTotalSessionCount();
-                        long counseleeCount = counselSessionRepository.countDistinctCounseleeForCurrentMonth();
-                        long totalCaringMessageCount = counselSessionRepository.count();
-                        double counselHours = calculateCounselHoursForThisMonth();
-
-                        return CounselSessionStatRes.builder()
-                                        .totalSessionCount(totalSessionCount)
-                                        .counseleeCountForThisMonth(counseleeCount)
-                                        .totalCaringMessageCount(totalCaringMessageCount)
-                                        .counselHoursForThisMonth((long) counselHours)
-                                        .build();
-                } catch (Exception e) {
-                        throw new RuntimeException("통계 정보 조회 중 오류가 발생했습니다", e);
-                }
-        }
-
-        private long calculateTotalSessionCount() {
-                try {
-                        return counselSessionRepository.countByStatus(ScheduleStatus.COMPLETED);
-                } catch (Exception e) {
-                        throw new RuntimeException("완료된 상담 세션 수 계산 중 오류 발생", e);
-                }
-        }
-
-        private double calculateCounselHoursForThisMonth() {
-                try {
-                        int year = LocalDateTime.now().getYear();
-                        int month = LocalDateTime.now().getMonthValue();
-                        List<CounselSession> completedSessions = counselSessionRepository
-                                        .findCompletedSessionsByYearAndMonth(year, month);
-
-                        return completedSessions.stream()
-                                        .mapToDouble(session -> {
-                                                Duration duration = Duration.between(
-                                                                session.getStartDateTime(),
-                                                                session.getEndDateTime());
-                                                return duration.toMinutes() / 60.0;
-                                        })
-                                        .sum();
-                } catch (Exception e) {
-                        throw new RuntimeException("이번 달 상담 시간 계산 중 오류 발생", e);
-                }
-        }
-
-        @Scheduled(cron = "0 0 * * * *") // 매시간 실행
-        @Transactional
-        public void cancelOverdueSessions() {
-                LocalDateTime now = LocalDateTime.now();
-                LocalDateTime twentyFourHoursAgo = now.minusHours(24);
-
-                List<CounselSession> overdueSessions = counselSessionRepository
-                                .findByStatusAndScheduledStartDateTimeBefore(
-                                                ScheduleStatus.SCHEDULED,
-                                                twentyFourHoursAgo);
-
-                overdueSessions.forEach(session -> {
-                        session.setStatus(ScheduleStatus.CANCELED);
-                        counselSessionRepository.save(session);
-                });
-        }
-
+    @Scheduled(cron = "0 0 * * * *") // 매시간 실행
+    @Transactional
+    public void cancelOverdueSessions() {
+        long updateCount = counselSessionRepository.cancelOverDueSessions();
+        log.info("취소된 상담 세션 수: {}", updateCount);
+    }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- CounseSession 리팩토링

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
- DTO 생성 from 함수를 사용하게 변경, 
- queryDSL 도입으로 필요 없어진 로직 제거
- SelectCounselSessionListByBaseDateAndCursorAndSizeRes -> CommonCursorRes 사용하게 변경 
- SelectCounselSessionListByBaseDateAndCursorAndSizeRes  삭제
- selectCounselSessionListByBaseDateAndCursorAndSize 함수 hasNext 로직 변경
   기존 로직은 다음과 같습니다.

  가져온 CounselSession의 개수를 요청에 있는 size와 비교함

  ```java
  boolean hasNext = sessions.size() == req.getSize();
  ```

  만약 CounselSession의 개수가 5개이고, 남은 CounselSession의 개수가 0개 일때,
  size가 5 이면 실제로는 다음 CounselSession은 없지만, CounselSession가 있다고 조회가 됨.

  이를 size + 1의 개수를 가져온 다음에 
  ```java
  boolean hasNext = sessions.size() > pageable.getPageSize();
  ```
  로 비교하게 되어, 위의 상황에서도 hasNext가 적절하게 생성되게 변경

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
- 

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
* 변경된 selectCounselSessionListByBaseDateAndCursorAndSize 함수 로직이 맞는지 검증이 필요합니다.
* selectCounselSessionListByBaseDateAndCursorAndSize  함수의 경우 6번의 쿼리를 불러오는쿼리 최적화가 필요합니다.