### PR TITLE
feat: add patchCounselSession

### DIFF
--- a/src/main/java/com/springboot/api/counselsession/entity/CounselSession.java
+++ b/src/main/java/com/springboot/api/counselsession/entity/CounselSession.java
@@ -75,6 +75,12 @@ public class CounselSession extends BaseEntity {
     @OneToOne(mappedBy = "counselSession", cascade = CascadeType.ALL)
     private CounselCard counselCard;
 
+    public CounselSession(Counselee counselee, LocalDateTime scheduledStartDateTime) {
+        this.counselee = Objects.requireNonNull(counselee, "상담 세션의 내담자는 필수 입력 항목입니다.");
+        this.scheduledStartDateTime = Objects.requireNonNull(scheduledStartDateTime, "상담 세션의 시작 시간은 필수 입력 항목입니다.");
+        this.status = ScheduleStatus.SCHEDULED;
+    }
+
     @PrePersist
     @Override
     protected void onCreate() {

--- a/src/main/java/com/springboot/api/counselsession/service/CounselSessionService.java
+++ b/src/main/java/com/springboot/api/counselsession/service/CounselSessionService.java
@@ -306,4 +306,27 @@ public class CounselSessionService {
 
                 return SelectCounselSessionPageRes.of(page);
         }
+
+
+        public String patchCounselSession(String counseleeId, String scheduledStartTime) {
+                LocalDateTime scheduledStartDateTime = dateTimeUtil.parseToDateTime(scheduledStartTime);
+                Counselee counselee = counseleeRepository.findById(counseleeId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 내담자 ID입니다"));
+
+                if (counselSessionRepository.existsByCounseleeAndScheduledStartDateTime(counselee,
+                    scheduledStartDateTime)) {
+                    return updateCounselSessionByCounselee(counselee, scheduledStartDateTime);
+                }
+                return createCounselSessionByCounselee(counselee, scheduledStartDateTime);
+        }
+
+        private String createCounselSessionByCounselee(Counselee counselee, LocalDateTime scheduledStartDateTime) {
+                CounselSession counselSession = new CounselSession(counselee, scheduledStartDateTime);
+                return counselSessionRepository.save(counselSession).getId();
+        }
+
+        // TODO update의 경우 어떻게 로직이 진행해야하는지 검토 필요
+        private String updateCounselSessionByCounselee(Counselee counselee, LocalDateTime scheduledStartDateTime) {
+                return null;
+        }
 }

--- a/src/test/java/com/springboot/api/service/CounselSessionServiceTest.java
+++ b/src/test/java/com/springboot/api/service/CounselSessionServiceTest.java
@@ -1,0 +1,88 @@
+package com.springboot.api.service;
+
+import com.springboot.api.common.util.DateTimeUtil;
+import com.springboot.api.counselee.entity.Counselee;
+import com.springboot.api.counselee.repository.CounseleeRepository;
+import com.springboot.api.counselsession.entity.CounselSession;
+import com.springboot.api.counselsession.repository.CounselSessionRepository;
+import com.springboot.api.counselsession.service.CounselSessionService;
+import com.springboot.enums.GenderType;
+import com.springboot.enums.HealthInsuranceType;
+import com.springboot.enums.ScheduleStatus;
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CounselSessionServiceTest {
+
+    @Spy
+    private DateTimeUtil dateTimeUtil;
+
+    @Mock
+    private CounselSessionRepository counselSessionRepository;
+
+    @Mock
+    private CounseleeRepository counseleeRepository;
+
+    @InjectMocks
+    private CounselSessionService counselSessionService;
+
+    @Test
+    @DisplayName("patchCounselSession이 CounselSession이 없을 경우에 예약을 생성한다.")
+    public void testPatchCounselSession_CreateCounselSession() {
+        // Given
+        Counselee counselee = Counselee.builder()
+            .name("홍박사")
+            .dateOfBirth(LocalDate.of(1980, 1, 1))
+            .phoneNumber("010-1234-5678")
+            .genderType(GenderType.MALE)
+            .healthInsuranceType(HealthInsuranceType.HEALTH_INSURANCE)
+            .counselCount(0)
+            .registrationDate(LocalDate.now())
+            .build();
+
+        String scheduledStartDateTime = "2024-01-01 10:00";
+        LocalDateTime scheduleDateTime = dateTimeUtil.parseToDateTime(scheduledStartDateTime);
+
+        CounselSession counselSession = Mockito.spy(CounselSession.builder()
+            .counselee(counselee)
+            .scheduledStartDateTime(scheduleDateTime)
+            .status(ScheduleStatus.SCHEDULED)
+            .build());
+
+        given(counseleeRepository.findById(any(String.class))).willReturn(java.util.Optional.of(counselee));
+        given(counselSessionRepository.existsByCounseleeAndScheduledStartDateTime(counselee, scheduleDateTime)).willReturn(false);
+        given(counselSessionRepository.save(any())).willReturn(counselSession);
+        given(counselSession.getId()).willReturn("01JNBYN04P2JGB7CVQBPX02EXD");
+        // When
+        String sessionId = counselSessionService.patchCounselSession("01JNBYN04P2JGB7CVQBPX02EXD", scheduledStartDateTime);
+        // Then
+        Assertions.assertThat(counselSession.getId()).isEqualTo(sessionId);
+    }
+
+    @Test
+    @DisplayName("patchCounselSession이 Counselee가 없을 경우에 예외를 발생시킨다.")
+    public void testPatchCounselSession_ThrowExceptionWhenCounseleeNotFound() {
+        // Given
+        String scheduledStartDateTime = "2024-01-01 10:00";
+        given(counseleeRepository.findById(any(String.class))).willReturn(java.util.Optional.empty());
+        // When
+        // Then
+        Assertions.assertThatThrownBy(() -> counselSessionService.patchCounselSession("01JNBYN04P2JGB7CVQBPX02EXD", scheduledStartDateTime))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("존재하지 않는 내담자 ID입니다");
+    }
+}

--- a/src/test/java/com/springboot/api/service/CounseleeServiceTest.java
+++ b/src/test/java/com/springboot/api/service/CounseleeServiceTest.java
@@ -1,26 +1,25 @@
 package com.springboot.api.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.springboot.api.counselee.dto.SelectCounseleeAutocompleteRes;
 import com.springboot.api.counselee.entity.Counselee;
 import com.springboot.api.counselee.repository.CounseleeRepository;
 import com.springboot.api.counselee.service.CounseleeService;
 import com.springboot.enums.GenderType;
 import com.springboot.enums.HealthInsuranceType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CounseleeServiceTest {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- counselSession 생성 및 업데이트 API 구현

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
- counselSession 생성 및 업데이트 API 구현

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
- 없음

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
- 이 PR은 실제로 코드를 merge하는 것이 목표가 아니라, 현재 이런 상황의 문제가 생겼다는 것을 알리기 위한 PR입니다.
- patchCounselSession이라는 함수를 service에서 생성하는 도중에 문제가 발생했습니다.
- 저는 CounselSession의 생성 조건을 다음과 같이 보았습니다.

  1. Counselee가 존재한다.
  2. Counselee가 ScheduledDateTime에 CounselSession이 존재하지 않는다.
  
  이 경우에서 CounselSession 생성 자체는 가능합니다.
   
  그럼 수정에서는 다음 조건을 만족시킨다고 가정하겠습니다.
  
  1. Counselee가 존재한다.
  2. Counselee가 ScheduledDateTime에 CounselSession이 존재한다.

  그러나 문제는 CounselSession이 이렇게 조회가 될 경우 수정을 할 수가 없습니다. Counselee와 ScheduledDateTime이 동일하기 때문입니다.

  그래서 현재 만들어야하는 API의 요구사항이 변경되어야 할 것 같습니다.
  
  ![image](https://github.com/user-attachments/assets/7ad8bc59-0b6f-4d1a-a4c7-65751052ea67)

  이 UI를 보면, 내담자에게 상담일정을 등록해주는 API 같습니다.(상담자는 등록하지 않은 상태로)
  수정은 아마 상담 세션의 ScheduledDateTime을 조정하는 것 같습니다.

  현재 API 요구 조건을 다음과 같이 바꿔야한다고 생각합니다.
  
  1. 내담자에게 상담 세션(상담자 없이) 등록 API 
     Request : counseleeId,  ScheduledDateTime
     Response : counselSessionId

  2. 내담자에게 등록된 상담 세션의 시간 변경 API
     Request : counselSessionId, ScheduledDateTime
     Response : counselSessionId
  
  2번의 경우 만약 상담자가 등록되어 있다면, 상담자의 일정 또한 검증해서 변경을 해야하는지, 
  혹은 상담자가 등록되어있다면 오류를 발생시켜야 하는지가 궁금합니다.
  
##### 📌 PR 진행 시 이러한 점들을 참고해 주세요

```
- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 7일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3, P4, P5 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
    - P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
    - P5: 그냥 사소한 의견입니다 (Approve+Chore)
```
