### PR TITLE
Fix: stt file delete issue

### DIFF
--- a/src/main/java/com/springboot/api/common/properties/SttFileProperties.java
+++ b/src/main/java/com/springboot/api/common/properties/SttFileProperties.java
@@ -12,5 +12,5 @@ import lombok.Setter;
 @Setter
 public class SttFileProperties {
     private String origin;
-    private String covert;
+    private String convert;
 }

--- a/src/main/java/com/springboot/api/common/util/FileUtil.java
+++ b/src/main/java/com/springboot/api/common/util/FileUtil.java
@@ -1,23 +1,19 @@
 package com.springboot.api.common.util;
 
+import com.springboot.api.common.properties.FfmpegProperties;
+import de.huxhorn.sulky.ulid.ULID;
+import jakarta.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
-
-import com.springboot.api.common.dto.ByteArrayMultipartFile;
-import com.springboot.api.common.properties.FfmpegProperties;
-
-import de.huxhorn.sulky.ulid.ULID;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import net.bramp.ffmpeg.FFmpeg;
 import net.bramp.ffmpeg.builder.FFmpegBuilder;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @RequiredArgsConstructor
@@ -27,14 +23,7 @@ public class FileUtil {
 
     private final FfmpegProperties ffmpegProperties;
 
-    public File convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
-        File tempFile = File.createTempFile("upload_", multipartFile.getOriginalFilename());
-        multipartFile.transferTo(tempFile);
-        return tempFile;
-    }
-
-    private String saveMultipartFile(@NotNull MultipartFile multipartFile, @NotNull String saveFilePath)
-            throws IOException {
+    public String saveMultipartFile(@NotNull MultipartFile multipartFile, @NotNull String saveFilePath) throws IOException {
 
         if (multipartFile.isEmpty()) {
             throw new IllegalArgumentException();
@@ -48,6 +37,7 @@ public class FileUtil {
 
         String hash = new ULID().nextULID();
         String hashedFilename = hash + multipartFile.getOriginalFilename();
+        hashedFilename = hashedFilename.replaceAll("\\s+", "");
 
         log.debug(hashedFilename);
 
@@ -55,20 +45,20 @@ public class FileUtil {
 
         Files.copy(multipartFile.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
 
+
         return hashedFilename;
 
     }
 
-    public MultipartFile convertWebmToMp4(MultipartFile multipartFile, String originFilePath, String convertFilePath)
+    public File convertWebmToMp4(String fileName, String originFilePath, String convertFilePath)
             throws IOException {
 
-        String savedMultipartFileName = saveMultipartFile(multipartFile, originFilePath);
-        String convertedMultipartFileName = savedMultipartFileName.replace(".webm", ".mp4");
+        String convertedMultipartFileName = fileName.replace(".webm", ".mp4");
 
         FFmpeg ffmpeg = new FFmpeg(ffmpegProperties.getPath());
 
         FFmpegBuilder builder = new FFmpegBuilder()
-                .setInput(originFilePath + savedMultipartFileName)
+                .setInput(originFilePath + fileName)
                 .overrideOutputFiles(true)
                 .addOutput(convertFilePath + convertedMultipartFileName) // 출력 파일 설정
                 .setFormat("mp4") // 출력 포맷 설정
@@ -78,15 +68,12 @@ public class FileUtil {
 
         ffmpeg.run(builder);
 
-        File mp4File = new File(convertFilePath + convertedMultipartFileName);
-        byte[] fileBytes = Files.readAllBytes(mp4File.toPath());
-        MultipartFile convertedMultipartFile = new ByteArrayMultipartFile("media", convertedMultipartFileName,
-                "audio/mp4", fileBytes);
+        return Path.of(convertFilePath+convertedMultipartFileName).toFile();
+    }
 
-        Files.delete(Path.of(originFilePath + savedMultipartFileName));
-        Files.delete(Path.of(convertFilePath + convertedMultipartFileName));
+    public void deleteFile(@NotNull String filePath,@NotNull String fileName) throws IOException {
 
-        return convertedMultipartFile;
+        Files.delete(Path.of(filePath + fileName));
     }
 
 }

--- a/src/main/java/com/springboot/api/common/util/FileUtil.java
+++ b/src/main/java/com/springboot/api/common/util/FileUtil.java
@@ -71,9 +71,4 @@ public class FileUtil {
         return Path.of(convertFilePath+convertedMultipartFileName).toFile();
     }
 
-    public void deleteFile(@NotNull String filePath,@NotNull String fileName) throws IOException {
-
-        Files.delete(Path.of(filePath + fileName));
-    }
-
 }

--- a/src/main/java/com/springboot/api/counselsession/controller/AICounselSummaryController.java
+++ b/src/main/java/com/springboot/api/counselsession/controller/AICounselSummaryController.java
@@ -1,18 +1,5 @@
 package com.springboot.api.counselsession.controller;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.springboot.api.common.annotation.ApiController;
 import com.springboot.api.common.dto.CommonRes;
@@ -26,10 +13,21 @@ import com.springboot.api.counselsession.dto.aiCounselSummary.SelectAnalysedText
 import com.springboot.api.counselsession.dto.aiCounselSummary.SelectSpeakerListRes;
 import com.springboot.api.counselsession.dto.aiCounselSummary.SelectSpeechToTextRes;
 import com.springboot.api.counselsession.service.AICounselSummaryService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @ApiController(name = "AICounselSummaryController", path = "/v1/counsel/ai", description = "본상담 내 AI요약 관련 API를 제공하는 Controller")
 @RequiredArgsConstructor
@@ -39,9 +37,9 @@ public class AICounselSummaryController {
 
     @PostMapping(value = "/stt", consumes = "multipart/form-data")
     @Operation(summary = "convert Speech to Text", tags = { "AI요약" })
-    public ResponseEntity<SuccessRes> convertSpeechToText(
+    public ResponseEntity<SuccessRes> convertSpeechToText (
             @RequestPart("audio") MultipartFile file,
-            @RequestPart("body") @Valid ConvertSpeechToTextReq convertSpeechToTextReq) {
+            @RequestPart("body") @Valid ConvertSpeechToTextReq convertSpeechToTextReq) throws IOException {
         aiCounselSummaryService.convertSpeechToText(file, convertSpeechToTextReq);
         return ResponseEntity.ok(new SuccessRes());
 

--- a/src/main/java/com/springboot/api/counselsession/controller/AICounselSummaryController.java
+++ b/src/main/java/com/springboot/api/counselsession/controller/AICounselSummaryController.java
@@ -69,7 +69,7 @@ public class AICounselSummaryController {
     @GetMapping("{counselSessionId}/ta")
     @Operation(summary = "ta 결과 조회", tags = { "AI요약" })
     public ResponseEntity<CommonRes<SelectAnalysedTextRes>> selectAnalysedText(
-            @PathVariable String counselSessionId) throws JsonProcessingException {
+            @PathVariable String counselSessionId) {
 
         SelectAnalysedTextRes selectAnalysedTextRes = aiCounselSummaryService.selectAnalysedText(counselSessionId);
 

--- a/src/main/java/com/springboot/api/counselsession/service/AICounselSummaryService.java
+++ b/src/main/java/com/springboot/api/counselsession/service/AICounselSummaryService.java
@@ -122,7 +122,6 @@ public class AICounselSummaryService {
                                                 log.warn("Failed to delete temp file: {}", originFileName, e);
                                          }
                         });
-                ;
 
         }
 

--- a/src/main/java/com/springboot/api/counselsession/service/AICounselSummaryService.java
+++ b/src/main/java/com/springboot/api/counselsession/service/AICounselSummaryService.java
@@ -5,7 +5,6 @@ import static com.springboot.api.counselsession.enums.AICounselSummaryStatus.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.springboot.api.common.dto.ByteArrayMultipartFile;
 import com.springboot.api.common.exception.NoContentException;
 import com.springboot.api.common.properties.NaverClovaProperties;
 import com.springboot.api.common.properties.SttFileProperties;
@@ -23,7 +22,11 @@ import com.springboot.api.counselsession.repository.AICounselSummaryRepository;
 import com.springboot.api.counselsession.repository.CounselSessionRepository;
 import com.springboot.api.counselsession.repository.PromptTemplateRepository;
 import com.springboot.api.infra.external.NaverClovaExternalService;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +41,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,7 +64,7 @@ public class AICounselSummaryService {
 
         private final FileUtil fileUtil;
 
-        public void convertSpeechToText(MultipartFile file, ConvertSpeechToTextReq convertSpeechToTextReq) {
+        public void convertSpeechToText(MultipartFile multipartFile, ConvertSpeechToTextReq convertSpeechToTextReq) throws IOException {
 
                 CounselSession counselSession = counselSessionRepository
                                 .findById(convertSpeechToTextReq.getCounselSessionId())
@@ -95,7 +99,9 @@ public class AICounselSummaryService {
                                 .fullText(true)
                                 .build();
 
-                callNaverClovaAsync(headers, file, speechToTextReq)
+                String originFileName = fileUtil.saveMultipartFile(multipartFile, sttFileProperties.getOrigin());
+
+                callNaverClovaAsync(headers, originFileName, speechToTextReq)
                                 .thenAcceptAsync(speechToTextRes -> updateAiCounselSummaryStatus(aiCounselSummary,
                                                 "COMPLETED".equals(speechToTextRes.result()) ? STT_COMPLETE
                                                                 : STT_FAILED,
@@ -106,27 +112,35 @@ public class AICounselSummaryService {
                                         log.error("Speech-to-text processing error", ex);
                                         updateAiCounselSummaryStatus(aiCounselSummary, STT_FAILED, null);
                                         return null;
-                                });
+                                })
+                                .whenComplete((result, throwable) -> {
+                                        // ✅ 성공/실패 여부 상관없이 파일 삭제
+                                        try {
+                                                Files.deleteIfExists(Path.of(sttFileProperties.getOrigin()+originFileName));
+                                                Files.deleteIfExists(Path.of(sttFileProperties.getConvert()+originFileName.replace(".webm",".mp4")));
+                                        } catch (IOException e) {
+                                                log.warn("Failed to delete temp file: {}", originFileName, e);
+                                         }
+                        });
+                ;
 
         }
 
         @Async
-        public CompletableFuture<SpeechToTextRes> callNaverClovaAsync(Map<String, String> headers, MultipartFile file,
+        public CompletableFuture<SpeechToTextRes> callNaverClovaAsync(Map<String, String> headers, String  originFileName,
                         SpeechToTextReq request) {
                 return CompletableFuture.supplyAsync(() -> {
                         try {
-                                MultipartFile multipartFile;
+                                File sttReqFile = Paths.get(sttFileProperties.getOrigin(), originFileName).toFile();
 
-                                if (Objects.requireNonNull(file.getContentType()).contains("webm")) {
-                                        multipartFile = fileUtil.convertWebmToMp4(file, sttFileProperties.getOrigin(),
-                                                        sttFileProperties.getCovert());
-                                } else {
-                                        byte[] fileBytes = file.getBytes();
-                                        multipartFile = new ByteArrayMultipartFile(file.getName(),
-                                                        file.getOriginalFilename(), file.getContentType(), fileBytes);
+                                if (Objects.requireNonNull(sttReqFile.getName()).contains(".webm")) {
+                                        sttReqFile = fileUtil.convertWebmToMp4(sttReqFile.getName(), sttFileProperties.getOrigin(),
+                                                        sttFileProperties.getConvert());
                                 }
-                                return naverClovaExternalService.convertSpeechToText(headers, multipartFile, request)
+
+                                return naverClovaExternalService.convertSpeechToText(headers, new FileSystemResource(sttReqFile), request)
                                                 .getBody();
+
                         } catch (IOException e) {
                                 log.error("Error while reading file bytes", e);
                                 throw new CompletionException(e);

--- a/src/main/java/com/springboot/api/infra/external/NaverClovaExternalService.java
+++ b/src/main/java/com/springboot/api/infra/external/NaverClovaExternalService.java
@@ -1,20 +1,18 @@
 package com.springboot.api.infra.external;
 
+import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
+import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
 import java.util.Map;
-
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.service.annotation.PostExchange;
-
-import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
-import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
 
 public interface NaverClovaExternalService {
 
     @PostExchange("/recognizer/upload")
     ResponseEntity<SpeechToTextRes> convertSpeechToText(@RequestHeader Map<String, String> headers,
-            @RequestPart("media") MultipartFile multipartFile,
+            @RequestPart("media") FileSystemResource mediaFile,
             @RequestPart("params") SpeechToTextReq speechToTextReq);
 }

--- a/src/test/java/com/springboot/api/common/FileUtilTest.java
+++ b/src/test/java/com/springboot/api/common/FileUtilTest.java
@@ -7,7 +7,6 @@ import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
 import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
 import com.springboot.api.infra.external.NaverClovaExternalService;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +34,6 @@ public class FileUtilTest {
         void testConvertWebmToM4a(String filename) throws IOException {
 
                 File mp4File = ResourceUtils.getFile("classpath:" + "stt/audio/" + filename);
-                FileInputStream inputStream = new FileInputStream(mp4File);
                 String originPath = "/Users/choisunpil/Desktop/development/2024/spring-boot-boilerplate/src/test/resources/stt/audio/test/origin/";
                 String convertPath = "/Users/choisunpil/Desktop/development/2024/spring-boot-boilerplate/src/test/resources/stt/audio/test/convert/";
                 

--- a/src/test/java/com/springboot/api/common/FileUtilTest.java
+++ b/src/test/java/com/springboot/api/common/FileUtilTest.java
@@ -1,16 +1,22 @@
 package com.springboot.api.common;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.springboot.api.common.util.FileUtil;
+import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
+import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
+import com.springboot.api.infra.external.NaverClovaExternalService;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.client.RestTemplate;
@@ -18,13 +24,6 @@ import org.springframework.web.client.support.RestTemplateAdapter;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import org.springframework.web.util.DefaultUriBuilderFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.springboot.api.common.util.FileUtil;
-import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
-import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
-import com.springboot.api.infra.external.NaverClovaExternalService;
 
 @SpringBootTest
 @Disabled
@@ -48,7 +47,7 @@ public class FileUtilTest {
                                 "audio/webm",
                                 inputStream);
 
-                MultipartFile convertedMultipartFile = fileUtil.convertWebmToMp4(multipartFile, originPath,
+                File convertedFile = fileUtil.convertWebmToMp4(mp4File.getName(), originPath,
                                 convertPath);
 
                 RestTemplate restTemplate = new RestTemplate();
@@ -72,7 +71,7 @@ public class FileUtilTest {
                                 .build();
 
                 SpeechToTextRes speechToTextRes = service
-                                .convertSpeechToText(headers, convertedMultipartFile, speechToTextReq)
+                                .convertSpeechToText(headers, new FileSystemResource(convertedFile), speechToTextReq)
                                 .getBody();
 
                 ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/com/springboot/api/common/FileUtilTest.java
+++ b/src/test/java/com/springboot/api/common/FileUtilTest.java
@@ -17,11 +17,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.support.RestTemplateAdapter;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
@@ -40,12 +38,7 @@ public class FileUtilTest {
                 FileInputStream inputStream = new FileInputStream(mp4File);
                 String originPath = "/Users/choisunpil/Desktop/development/2024/spring-boot-boilerplate/src/test/resources/stt/audio/test/origin/";
                 String convertPath = "/Users/choisunpil/Desktop/development/2024/spring-boot-boilerplate/src/test/resources/stt/audio/test/convert/";
-
-                MultipartFile multipartFile = new MockMultipartFile(
-                                "media",
-                                mp4File.getName(),
-                                "audio/webm",
-                                inputStream);
+                
 
                 File convertedFile = fileUtil.convertWebmToMp4(mp4File.getName(), originPath,
                                 convertPath);

--- a/src/test/java/com/springboot/api/common/STTTest.java
+++ b/src/test/java/com/springboot/api/common/STTTest.java
@@ -1,14 +1,19 @@
 package com.springboot.api.common;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.springboot.api.counselsession.dto.naverClova.DiarizationDTO;
+import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
+import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
+import com.springboot.api.infra.external.NaverClovaExternalService;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,22 +29,13 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.support.RestTemplateAdapter;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import org.springframework.web.util.DefaultUriBuilderFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.springboot.api.counselsession.dto.naverClova.DiarizationDTO;
-import com.springboot.api.counselsession.dto.naverClova.SpeechToTextReq;
-import com.springboot.api.counselsession.dto.naverClova.SpeechToTextRes;
-import com.springboot.api.infra.external.NaverClovaExternalService;
 
 @SpringBootTest
 @Disabled
@@ -71,14 +67,7 @@ public class STTTest {
                 headers.put("X-CLOVASPEECH-API-KEY", "6c294a231c7d42989a5ef003fd09c3d4");
 
                 File mp4File = ResourceUtils.getFile("classpath:" + "stt/audio/" + filename);
-                FileInputStream inputStream = new FileInputStream(mp4File);
-
-                MultipartFile multipartFile = new MockMultipartFile(
-                                "media",
-                                mp4File.getName(),
-                                "audio/m4a",
-                                inputStream);
-
+                
                 SpeechToTextReq speechToTextReq = SpeechToTextReq.builder()
                                 .language("ko-KR")
                                 .completion("sync")
@@ -90,7 +79,7 @@ public class STTTest {
                                                 .build())
                                 .build();
 
-                SpeechToTextRes speechToTextRes = service.convertSpeechToText(headers, multipartFile, speechToTextReq)
+                SpeechToTextRes speechToTextRes = service.convertSpeechToText(headers, new FileSystemResource(mp4File), speechToTextReq)
                                 .getBody();
 
                 ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
## ⛹️ 오류 상황

* Naver Clova speech API 사용해서 STT 진행.
  이때 해당 API 에서 지원하는 Format 중 webm은 없는 상황

* Backend에서 webm ->mp4 변환 필요해서
  OS에 설치한 **FFmpeg**(CLI Tool) 사용

* 원본, 변환 파일 경로는 아래와 같이 지정

  ```properties
  stt:
    file:
      path:
        origin: /data/stt/audio/origin/
        convert: /data/stt/audio/convert/
  ```

* 원본파일 저장은 비동기로 작업되며
   Multipart(톰캣 하위 임시 경로에 *.tmp 형태로 저장되어 있는 정보) -> stt.file.path.origin 에 저장함.
  이때 간헐적으로 Multipart에서 참고하는 파일 없다는 오류 발생함.



## ❤️ Exception Stack Trace

```
2025-03-15 05:27:53 ERROR [ForkJoinPool.commonPool-worker-7] c.s.a.c.s.AICounselSummaryService - Speech-to-text processing error
java.util.concurrent.CompletionException: java.nio.file.NoSuchFileException: /tmp/tomcat.8080.7985687605238157848/work/Tomcat/localhost/api/upload_784719b3_41bc_4192_b423_b4b10769c9b4_00000004.tmp
	at com.springboot.api.counselsession.service.AICounselSummaryService.lambda$callNaverClovaAsync$2(AICounselSummaryService.java:134)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.nio.file.NoSuchFileException: /tmp/tomcat.8080.7985687605238157848/work/Tomcat/localhost/api/upload_784719b3_41bc_4192_b423_b4b10769c9b4_00000004.tmp
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:261)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:379)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:431)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:159)
	at org.apache.tomcat.util.http.fileupload.disk.DiskFileItem.getInputStream(DiskFileItem.java:196)
	at org.apache.catalina.core.ApplicationPart.getInputStream(ApplicationPart.java:97)
	at org.springframework.web.multipart.support.StandardMultipartHttpServletRequest$StandardMultipartFile.getInputStream(StandardMultipartHttpServletRequest.java:260)
	at com.springboot.api.common.util.FileUtil.saveMultipartFile(FileUtil.java:56)
	at com.springboot.api.common.util.FileUtil.convertWebmToMp4(FileUtil.java:65)
	at com.springboot.api.counselsession.service.AICounselSummaryService.lambda$callNaverClovaAsync$2(AICounselSummaryService.java:123)
	... 7 common frames omitted
```



## 🥶 오류 원인

* 톰캣 하위 임시 경로에 저장된 파일이 **비동기 메소드**에서 **사용하기 전**에
   삭제 되어 비동기 메소드에서 파일 참조 시 파일이 없어서 오류 발생함,



## 🔍️ 해결 방안

- **요청 Transaction 내에서 File 로 저장 하고 비동기 메소드 호출되도록 수정** => 채택

  - 

- Tomcat 설정 변경

  * 메모리 or 파일 기준 용량 설정 변경
  * Tomcat이 삭제하지 않는 다른 영역으로 multipart 저장 경로 변경

  ```properties
  spring.servlet.multipart.file-size-threshold=2MB
  spring.servlet.multipart.location=/opt/app-uploads
  ```

  



## 이번 이슈 통해서 다시 개념 잡은 부분

* Request Multipart 객체는 File을 다룰때 1MB(변경 가능)
  기준 보다 작으면 메모리에 바로 올리고 기준 보다 크면 *.tmp 파일을 만들어 File 참조하는 형태로 사용함.
  * *.tmp 파일은 해당 Transaction 끝나면 Tomcat이 삭제하기 때문에 Multipart 비동기 처리 시 여러 옵션 고려해야함(파일 경로 변경, delete time delay, 기준 file size 조절 등등)



## 그 외 식별된 이슈

* propeties 명 잘못되어 있는 이슈 식별하여 조치(covert -> convert)

##### 📌 PR 진행 시 이러한 점들을 참고해 주세요

```
- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 7일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3, P4, P5 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
    - P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
    - P5: 그냥 사소한 의견입니다 (Approve+Chore)
```

------

## 📝 Assignee를 위한 CheckList

-  To-Do Item